### PR TITLE
Explicitly declare babel-core and node-libs-browser in devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "asar": "^0.6.1",
     "babel-loader": "^5.1.2",
+    "babel-core": "^5.4.2",    
     "chai": "^2.3.0",
     "css-loader": "^0.12.1",
     "del": "^1.2.0",
@@ -60,7 +61,8 @@
     "style-loader": "^0.12.2",
     "url-loader": "^0.5.5",
     "webpack": "^1.9.7",
-    "webpack-dev-server": "^1.8.2"
+    "webpack-dev-server": "^1.8.2",
+    "node-libs-browser": ">= 0.4.0 <=0.6.0"
   },
   "dependencies": {
     "debug": "^2.2.0",


### PR DESCRIPTION
```babel-core``` is required by ```babel-loader``` and its size is ~19 MB.
```node-libs-browser``` is required by ```webpack``` and its size is ~3MB.
If we explicitly define it as dev deps - it won't be copied to the release. As the result, the release will have ~22 MB less size, which is about 20%.