### PR TITLE
Simplify Electron executable scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,6 @@ npm run hot-dev-server
 npm run start-hot
 ```
 
-To start a react-hot electron app development !
-
-> Please make sure you have a `electron` environment variable which is linked to your Electron binary in your terminal. Otherwise you should refer [Run your app](https://github.com/atom/electron/blob/master/docs/tutorial/quick-start.md#run-your-app) document for run this on your computer.
-
 ## Externals
 
 If you use any 3rd party libraries which can't be built with webpack, you must list them in your `webpack/make-webpack-config.js`：

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "bin":{
     "electron":"./node_modules/.bin/electron"
-  }
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chentsulin/electron-react-boilerplate.git"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "package": "node package.js",
     "package-all": "node package.js --all"
   },
+  "bin":{
+    "electron":"./node_modules/.bin/electron"
+  }
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chentsulin/electron-react-boilerplate.git"


### PR DESCRIPTION
Created a bin link to `./node_modules/.bin/electron`, eliminating the need to have `electron` on your environment, and simultaneously making `scripts` easier to write.