### PR TITLE
Add productName to package.json

### DIFF
--- a/package.js
+++ b/package.js
@@ -8,10 +8,10 @@ const packager = require('electron-packager');
 const del = require('del');
 const exec = require('child_process').exec;
 const argv = require('minimist')(process.argv.slice(2));
-const devDeps = Object.keys(require('./package.json').devDependencies);
+const pkg = require('./package.json');
+const devDeps = Object.keys(pkg.devDependencies);
 
-
-const appName = argv.name || argv.n || 'ElectronReact';
+const appName = argv.name || argv.n || pkg.productName;
 const shouldUseAsar = argv.asar || argv.a || false;
 const shouldBuildAll = argv.all || false;
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "electron-react-boilerplate",
+  "productName": "ElectronReact",
   "version": "0.7.0-beta",
   "description": "Electron application boilerplate based on React, React Router, Webpack, React Hot Loader for rapid application development",
   "main": "main.js",


### PR DESCRIPTION
https://github.com/atom/electron/blob/master/docs/api/app.md#appgetname

Electron `app.getName()` default used productName of `package.json`, so we can use it to replace default appName of `package.js`.