### PR TITLE
package script now chooses correct OS icon extension

### DIFF
--- a/package.js
+++ b/package.js
@@ -92,7 +92,7 @@ function pack(plat, arch, cb) {
         extension = '.ico';
       }
       return extension;
-    }())
+    })()
   };
   
   const opts = Object.assign({}, DEFAULT_OPTS, iconObj, {

--- a/package.js
+++ b/package.js
@@ -92,7 +92,7 @@ function pack(plat, arch, cb) {
         extension = '.ico';
       }
       return extension;
-    })
+    }())
   };
   
   const opts = Object.assign({}, DEFAULT_OPTS, iconObj, {

--- a/package.js
+++ b/package.js
@@ -27,7 +27,7 @@ const DEFAULT_OPTS = {
   ].concat(devDeps.map(name => `/node_modules/${name}($|/)`))
 };
 
-const icon = argv.icon || argv.i || 'app/app.icns';
+const icon = argv.icon || argv.i || 'app/app';
 
 if (icon) {
   DEFAULT_OPTS.icon = icon;
@@ -83,7 +83,19 @@ function pack(plat, arch, cb) {
   // there is no darwin ia32 electron
   if (plat === 'darwin' && arch === 'ia32') return;
 
-  const opts = Object.assign({}, DEFAULT_OPTS, {
+  const iconObj = {
+    icon: DEFAULT_OPTS.icon + (() => {
+      let extension = '.png';
+      if (plat === 'darwin') {
+        extension = '.icns';
+      } else if (plat === 'win32') {
+        extension = '.ico';
+      }
+      return extension;
+    })
+  };
+  
+  const opts = Object.assign({}, DEFAULT_OPTS, iconObj, {
     platform: plat,
     arch,
     prune: true,

--- a/package.js
+++ b/package.js
@@ -94,7 +94,7 @@ function pack(plat, arch, cb) {
       return extension;
     })()
   };
-  
+
   const opts = Object.assign({}, DEFAULT_OPTS, iconObj, {
     platform: plat,
     arch,


### PR DESCRIPTION
The packaging script now appends a different icon extension depending on the platform:

* win32 needs an .ico
* darwin needs an .icns
* everything else (i.e., linux) needs a png.

This commit assumes an extensionless icon argument, and 3 icon files on disk (like the current script assumes 1) if you're doing a package-all and chooses the correct extension for the platform it's currently being built for.