### PR TITLE
Fix Webpack publicPath for production builds

### DIFF
--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -13,7 +13,7 @@ config.devtool = 'source-map';
 
 config.entry = './app/index';
 
-config.output.publicPath = '/dist/';
+config.output.publicPath = '../dist/';
 
 config.module.loaders.push({
   test: /^((?!\.module).)*\.css$/,


### PR DESCRIPTION
Previous value `/dist/` would cause static assets to be searched for in
`file:///dist/...` (root of fs), instead of in the `dist/` directory
relative to `app/index.html`.