### PR TITLE
Use babel-plugin-transform-runtime instead of babel-polyfill

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": ["es2015", "stage-0", "react"],
-  "plugins": ["add-module-exports"],
+  "plugins": ["add-module-exports", "transform-runtime"],
   "env": {
     "development": {
       "presets": ["react-hmre"]

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "cross-env NODE_ENV=test mocha --compilers js:babel-core/register --recursive --require ./test/setup.js test/**/*.spec.js",
     "test-watch": "npm test -- --watch",
-    "test-e2e": "cross-env NODE_ENV=test mocha --compilers js:babel-core/register --require ./test/setup.js --require co-mocha ./test/e2e.js",
+    "test-e2e": "cross-env NODE_ENV=test mocha --compilers js:babel-core/register --require co-mocha ./test/e2e.js",
     "lint": "eslint app test *.js",
     "hot-server": "node server.js",
     "build": "cross-env NODE_ENV=production webpack --config webpack.config.production.js --progress --profile --colors",
@@ -49,8 +49,8 @@
     "babel-eslint": "^5.0.0-beta6",
     "babel-loader": "^6.2.0",
     "babel-plugin-add-module-exports": "^0.1.2",
+    "babel-plugin-transform-runtime": "^6.5.2",
     "babel-plugin-webpack-loaders": "^0.2.1",
-    "babel-polyfill": "^6.3.14",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-react-hmre": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "babel-preset-react": "^6.3.13",
     "babel-preset-react-hmre": "^1.0.1",
     "babel-preset-stage-0": "^6.3.13",
+    "babel-runtime": "^6.5.0",
     "chai": "^3.3.0",
     "chromedriver": "^2.19.0",
     "co-mocha": "^1.1.2",

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,4 +1,3 @@
-import 'babel-polyfill';
 import { jsdom } from 'jsdom';
 
 global.document = jsdom('<!doctype html><html><body></body></html>');


### PR DESCRIPTION
Related https://github.com/SeleniumHQ/selenium/issues/1627.

Maybe caused by a recent babel update, the E2E test is not work.

If someone needs `core-js`, I would recommend use v2.0, or wait babel update.