### PR TITLE
Added start (hot-server, start-hot) servers with one command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,8 @@ $ npm install
 
 ## Run
 
-Run this two commands __simultaneously__ in different console tabs.
-
 ```bash
-$ npm run hot-server
-$ npm run start-hot
+$ npm run dev
 ```
 
 *Note: requires a node version >= 4 and an npm version >= 2.*

--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ $ npm install
 
 ## Run
 
+Run this two commands __simultaneously__ in different console tabs.
+
+```bash
+$ npm run hot-server
+$ npm run start-hot
+```
+
+or run two servers with one command
+
 ```bash
 $ npm run dev
 ```

--- a/package.json
+++ b/package.json
@@ -9,22 +9,14 @@
     "test-watch": "npm test -- --watch",
     "test-e2e": "cross-env NODE_ENV=test mocha --compilers js:babel-core/register --require ./test/setup.js --require co-mocha ./test/e2e.js",
     "lint": "eslint app test *.js",
-    "hot-server": "better-npm-run hot-server",
+    "hot-server": "node server.js",
     "build": "cross-env NODE_ENV=production webpack --config webpack.config.production.js --progress --profile --colors",
     "start": "cross-env NODE_ENV=production electron ./",
-    "start-hot": "better-npm-run start-hot",
+    "start-hot": "cross-env HOT=1 NODE_ENV=development electron ./",
     "package": "cross-env NODE_ENV=production node package.js",
     "package-all": "npm run package -- --all",
     "postinstall": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json",
     "dev": "concurrently --kill-others \"npm run hot-server\" \"npm run start-hot\""
-  },
-  "betterScripts": {
-    "hot-server": {
-      "command": "node server.js"
-    },
-    "start-hot": {
-      "command": "cross-env HOT=1 NODE_ENV=development electron ./"
-    }
   },
   "bin": {
     "electron": "./node_modules/.bin/electron"
@@ -96,7 +88,6 @@
     "webpack-dev-middleware": "^1.2.0",
     "webpack-hot-middleware": "^2.4.1",
     "webpack-target-electron-renderer": "^0.3.0",
-    "better-npm-run": "^0.0.7",
     "concurrently": "^2.0.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,13 +9,22 @@
     "test-watch": "npm test -- --watch",
     "test-e2e": "cross-env NODE_ENV=test mocha --compilers js:babel-core/register --require ./test/setup.js --require co-mocha ./test/e2e.js",
     "lint": "eslint app test *.js",
-    "hot-server": "node server.js",
+    "hot-server": "better-npm-run hot-server",
     "build": "cross-env NODE_ENV=production webpack --config webpack.config.production.js --progress --profile --colors",
     "start": "cross-env NODE_ENV=production electron ./",
-    "start-hot": "cross-env HOT=1 NODE_ENV=development electron ./",
+    "start-hot": "better-npm-run start-hot",
     "package": "cross-env NODE_ENV=production node package.js",
     "package-all": "npm run package -- --all",
-    "postinstall": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json"
+    "postinstall": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json",
+    "dev": "concurrently --kill-others \"npm run hot-server\" \"npm run start-hot\""
+  },
+  "betterScripts": {
+    "hot-server": {
+      "command": "node server.js"
+    },
+    "start-hot": {
+      "command": "cross-env HOT=1 NODE_ENV=development electron ./"
+    }
   },
   "bin": {
     "electron": "./node_modules/.bin/electron"
@@ -86,7 +95,9 @@
     "webpack": "^1.12.1",
     "webpack-dev-middleware": "^1.2.0",
     "webpack-hot-middleware": "^2.4.1",
-    "webpack-target-electron-renderer": "^0.3.0"
+    "webpack-target-electron-renderer": "^0.3.0",
+    "better-npm-run": "^0.0.7",
+    "concurrently": "^2.0.0"
   },
   "dependencies": {
     "electron-debug": "^0.5.1",


### PR DESCRIPTION
Keep open two terminals is bad.
So I added the ability to run two servers with a single command (npm run dev). 
I hope this opportunity will be useful to others.