### PR TITLE
Remove unused handler

### DIFF
--- a/server.js
+++ b/server.js
@@ -20,10 +20,6 @@ app.use(require('webpack-dev-middleware')(compiler, {
 
 app.use(require('webpack-hot-middleware')(compiler));
 
-app.get('*', (req, res) => {
-  res.sendFile(path.join(__dirname, 'app', 'hot-dev-app.html'));
-});
-
 app.listen(PORT, 'localhost', err => {
   if (err) {
     console.log(err);

--- a/server.js
+++ b/server.js
@@ -1,7 +1,6 @@
 /* eslint strict: 0, no-console: 0 */
 'use strict';
 
-const path = require('path');
 const express = require('express');
 const webpack = require('webpack');
 const config = require('./webpack.config.development');


### PR DESCRIPTION
Hello I don't understand why we need this handler
`app.use(require('webpack-hot-middleware')(compiler));` isn't enough?