### PR TITLE
Version of package is set based on the version in package.json

### DIFF
--- a/package.js
+++ b/package.js
@@ -99,6 +99,7 @@ function pack(plat, arch, cb) {
     platform: plat,
     arch,
     prune: true,
+    'app-version': pkg.version || DEFAULT_OPTS.version,
     out: `release/${plat}-${arch}`
   });
 


### PR DESCRIPTION
https://github.com/electron-userland/electron-packager has an option `app-version` that should be what the users sets in his package.json. It reverts to the default Electron version if nothing is found.