### PR TITLE
Remove output.publicPath from production config

### DIFF
--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -13,8 +13,6 @@ config.devtool = 'source-map';
 
 config.entry = './app/index';
 
-config.output.publicPath = '../dist/';
-
 config.module.loaders.push({
   test: /\.global\.css$/,
   loader: ExtractTextPlugin.extract(


### PR DESCRIPTION
As we have `output.path` in base.config