### PR TITLE
Fix `npm list electron-prebuilt` in package.js

### DIFF
--- a/package.js
+++ b/package.js
@@ -40,7 +40,7 @@ if (version) {
   startPack();
 } else {
   // use the same version as the currently-installed electron-prebuilt
-  exec('npm list electron-prebuilt', (err, stdout) => {
+  exec('npm list electron-prebuilt --dev', (err, stdout) => {
     if (err) {
       DEFAULT_OPTS.version = '0.36.9';
     } else {


### PR DESCRIPTION
The `npm run package` is included `npm_config_dev: ""` env, it means it don't check devDependencies.

Related to https://github.com/chentsulin/electron-react-boilerplate/pull/186#issuecomment-201340977.