### PR TITLE
Open application when webcontent is loaded

### DIFF
--- a/main.js
+++ b/main.js
@@ -27,9 +27,18 @@ app.on('window-all-closed', () => {
 
 
 app.on('ready', () => {
-  mainWindow = new BrowserWindow({ width: 1024, height: 728 });
+  mainWindow = new BrowserWindow({
+    show: false,
+    width: 1024,
+    height: 728
+  });
 
   mainWindow.loadURL(`file://${__dirname}/app/app.html`);
+
+  mainWindow.webContents.on('did-finish-load', () => {
+    mainWindow.show();
+    mainWindow.focus();
+  });
 
   mainWindow.on('closed', () => {
     mainWindow = null;


### PR DESCRIPTION
Open mainWindow when webContents is loaded using the event 'did-finish-load'.
This prevent having a blank window and then content "flash" in.  