### PR TITLE
fix typo Elecrton in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ We add some module's `peerDependencies` to ignore option as default for applicat
 
 Please checkout [Building windows apps from non-windows platforms](https://github.com/maxogden/electron-packager#building-windows-apps-from-non-windows-platforms).
 
-## How hot-reloading works on Elecrton
+## How hot-reloading works on Electron
 
 We use [webpack-target-electron-renderer](https://github.com/chentsulin/webpack-target-electron-renderer) to provide a build target for electron renderer process. Read more information [here](https://github.com/chentsulin/webpack-target-electron-renderer#how-this-module-works).
 


### PR DESCRIPTION
Just fixing a type I found in the readme.