### PR TITLE
Fix ignore regex to top level folders

### DIFF
--- a/package.js
+++ b/package.js
@@ -24,10 +24,10 @@ const DEFAULT_OPTS = {
   name: appName,
   asar: shouldUseAsar,
   ignore: [
-    '/test($|/)',
-    '/tools($|/)',
-    '/release($|/)',
-    '/main.development.js'
+    '^/test($|/)',
+    '^/tools($|/)',
+    '^/release($|/)',
+    '^/main.development.js'
   ].concat(devDeps.map(name => `/node_modules/${name}($|/)`))
   .concat(
     deps.filter(name => !electronCfg.externals.includes(name))


### PR DESCRIPTION
This was ignoring all folders named `release` in all node_modules

For instance bluebird ships with `js/browser` and `js/release` but `js/release` was ignored during the build process and filtered out.

https://github.com/petkaantonov/bluebird/blob/master/package.json#L71