### PR TITLE
extend output config in electron webpack config

### DIFF
--- a/webpack.config.electron.js
+++ b/webpack.config.electron.js
@@ -9,6 +9,7 @@ export default {
   entry: './main.development',
 
   output: {
+    ...baseConfig.output,
     path: __dirname,
     filename: './main.js'
   },


### PR DESCRIPTION
This is a fix for an issue I was running into with issue https://github.com/chentsulin/electron-react-boilerplate/issues/232

It adds an `output.libraryTarget` setting into `webpack.config.electron.js` by extending `baseConfig`