### PR TITLE
Add support for webpack-style imports in linter

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,5 +17,8 @@
   "plugins": [
     "import",
     "react"
-  ]
+  ],
+  "settings": {
+    "import/resolver": "webpack"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "electron-rebuild": "^1.1.4",
     "eslint": "^2.10.2",
     "eslint-config-airbnb": "^9.0.1",
+    "eslint-import-resolver-webpack": "^0.3.0",
     "eslint-plugin-import": "^1.8.1",
     "eslint-plugin-jsx-a11y": "^1.2.2",
     "eslint-plugin-react": "^5.1.1",


### PR DESCRIPTION
This change will prevent webpack compatible declarations from erroring. Previously declarations like below would cause an error.

```js
import 'file!./whatever'
```

https://www.npmjs.com/package/eslint-import-resolver-webpack