### PR TITLE
Prevent webpack.DefinePlugin to override process.env object

### DIFF
--- a/webpack.config.development.js
+++ b/webpack.config.development.js
@@ -48,9 +48,7 @@ const config = {
     new webpack.NoErrorsPlugin(),
     new webpack.DefinePlugin({
       __DEV__: true,
-      'process.env': {
-        NODE_ENV: JSON.stringify('development')
-      }
+      'process.env.NODE_ENV': JSON.stringify('development')
     })
   ],
 

--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -44,9 +44,7 @@ const config = {
     new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.DefinePlugin({
       __DEV__: false,
-      'process.env': {
-        NODE_ENV: JSON.stringify('production')
-      }
+      'process.env.NODE_ENV': JSON.stringify('production')
     }),
     new webpack.optimize.UglifyJsPlugin({
       compressor: {


### PR DESCRIPTION
This PR fixes issues with loosing `process.env` object.