### PR TITLE
Add UPGRADE_EXTENSIONS env for devtools-installer

### DIFF
--- a/main.development.js
+++ b/main.development.js
@@ -22,9 +22,10 @@ const installExtensions = async () => {
       'REACT_DEVELOPER_TOOLS',
       'REDUX_DEVTOOLS'
     ];
+    const forceDownload = !!process.env.UPGRADE_EXTENSIONS;
     for (const name of extensions) {
       try {
-        await installer.default(installer[name]);
+        await installer.default(installer[name], forceDownload);
       } catch (e) {} // eslint-disable-line
     }
   }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "css-loader": "^0.23.1",
     "del": "^2.2.0",
     "devtron": "^1.2.0",
-    "electron-devtools-installer": "^1.1.2",
+    "electron-devtools-installer": "^1.1.5",
     "electron-packager": "^7.0.2",
     "electron-prebuilt": "^1.2.3",
     "electron-rebuild": "^1.1.4",


### PR DESCRIPTION
Use `UPGRADE_EXTENSIONS=1 npm run start-hot` to force download extensions.