### PR TITLE
Fix .eslintrc import/resolver settings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,7 +10,7 @@
     "consistent-return": 0,
     "comma-dangle": 0,
     "no-use-before-define": 0,
-    "import/no-unresolved": [2, { ignore: ['electron'] }],
+    "import/no-unresolved": [2, { "ignore": ["electron"] }],
     "react/jsx-no-bind": 0,
     "react/prefer-stateless-function": 0
   },
@@ -19,6 +19,10 @@
     "react"
   ],
   "settings": {
-    "import/resolver": "webpack"
+    "import/resolver": {
+      "webpack": {
+        "config": "webpack.config.eslint.js"
+      }
+    }
   }
 }

--- a/webpack.config.eslint.js
+++ b/webpack.config.eslint.js
@@ -1,0 +1,3 @@
+require('babel-register');
+
+module.exports = require('./webpack.config.development');


### PR DESCRIPTION
Eslint webpack import resolver looks for 'webpack.config.js' file as a sibling of the first ancestral package.json. We have no 'webpack.config.js' here so we need to point resolver to some
custom path. Also, we can't point it directly to the 'webpack.config.development.js' file cause it uses ES6 stuff. In order to make eslint import resolver happy the 'webpack.config.eslint.js' is added as a babel-register wrapper around 'webpack.config.development.js'.

Also, invalid json (missing or single quotes) is fixed here as a bonus.