### PR TITLE
Add actionCreators option for window.devToolsExtension()

### DIFF
--- a/app/store/configureStore.development.js
+++ b/app/store/configureStore.development.js
@@ -2,8 +2,15 @@ import { createStore, applyMiddleware, compose } from 'redux';
 import thunk from 'redux-thunk';
 import createLogger from 'redux-logger';
 import { hashHistory } from 'react-router';
-import { routerMiddleware } from 'react-router-redux';
+import { routerMiddleware, push } from 'react-router-redux';
 import rootReducer from '../reducers';
+
+import * as counterActions from '../actions/counter';
+
+const actionCreators = {
+  ...counterActions,
+  push,
+};
 
 const logger = createLogger({
   level: 'info',
@@ -14,7 +21,9 @@ const router = routerMiddleware(hashHistory);
 
 const enhancer = compose(
   applyMiddleware(thunk, router, logger),
-  window.devToolsExtension ? window.devToolsExtension() : noop => noop
+  window.devToolsExtension ?
+    window.devToolsExtension({ actionCreators }) :
+    noop => noop
 );
 
 export default function configureStore(initialState) {

--- a/app/store/configureStore.development.js
+++ b/app/store/configureStore.development.js
@@ -29,6 +29,10 @@ const enhancer = compose(
 export default function configureStore(initialState) {
   const store = createStore(rootReducer, initialState, enhancer);
 
+  if (window.devToolsExtension) {
+    window.devToolsExtension.updateStore(store);
+  }
+
   if (module.hot) {
     module.hot.accept('../reducers', () =>
       store.replaceReducer(require('../reducers')) // eslint-disable-line global-require


### PR DESCRIPTION
The new feature [`Use action creators for Dispatcher`](https://github.com/zalmoxisus/redux-devtools-extension/releases/tag/v2.4.0) is supported on Redux DevTools Extension@2.4.

![2016-08-04 1 53 52](https://cloud.githubusercontent.com/assets/3001525/17391784/7026b602-5a4b-11e6-9256-c957c4018f7e.png)

Added counter actions & push action of `react-router-redux`.
