### PR TITLE
Remove remove console, debugger babel-plugin

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,8 +5,6 @@
     "production": {
       "presets": ["react-optimize"],
       "plugins": [
-        "babel-plugin-transform-remove-console",
-        "babel-plugin-transform-remove-debugger",
         "babel-plugin-dev-expression"
       ]
     },

--- a/package.json
+++ b/package.json
@@ -53,8 +53,6 @@
     "babel-loader": "^6.2.4",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-dev-expression": "^0.2.1",
-    "babel-plugin-transform-remove-console": "^6.8.0",
-    "babel-plugin-transform-remove-debugger": "^6.8.0",
     "babel-plugin-webpack-loaders": "^0.7.0",
     "babel-polyfill": "^6.9.1",
     "babel-preset-es2015": "^6.9.0",


### PR DESCRIPTION
Avoid those babel-plugins swallow console.log in `package.js`. Keeping `no-console` warning by linter should be enough.