### PR TITLE
Unify/fix .eslintrc quotation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,7 +13,7 @@
     "import/no-unresolved": [2, { "ignore": ["electron"] }],
     "import/no-extraneous-dependencies": 0,
     "react/jsx-no-bind": 0,
-    'react/jsx-filename-extension': [2, { extensions: ['.js', '.jsx'] }],
+    "react/jsx-filename-extension": [2, { "extensions": [".js", ".jsx"] }],
     "react/prefer-stateless-function": 0
   },
   "plugins": [


### PR DESCRIPTION
eslint wants it's property keys doublequoted.