### PR TITLE
Update for Electron Packager 8

### DIFF
--- a/package.js
+++ b/package.js
@@ -132,7 +132,7 @@ function pack(plat, arch, cb) {
 
   const opts = Object.assign({}, DEFAULT_OPTS, {
     platform: plat,
-    arch: arch,
+    arch,
     out: `release/${plat}-${arch}`
   });
 

--- a/package.js
+++ b/package.js
@@ -22,12 +22,10 @@ const argv = require('minimist')(process.argv.slice(2));
 
 /**
  * Do not package node modules from 'devDependencies'
- * and 'dependencies' that are set as external
+ * (automatically done by electron-packager) and
+ * 'dependencies' that are set as external
  */
 const toNodePath = name => `/node_modules/${name}($|/)`;
-const devDeps = Object
-  .keys(pkg.devDependencies)
-  .map(toNodePath);
 
 const depsExternal = Object
   .keys(pkg.dependencies)
@@ -49,7 +47,6 @@ const DEFAULT_OPTS = {
     '^/release($|/)',
     '^/main.development.js'
   ]
-  .concat(devDeps)
   .concat(depsExternal)
 };
 
@@ -59,20 +56,18 @@ if (icon) DEFAULT_OPTS.icon = icon;
 const version = argv.version || argv.v;
 if (version) {
   DEFAULT_OPTS.version = version;
-  startPack();
 } else {
-  // use the same version as the currently-installed electron-prebuilt
+  // use the same version as the currently-installed electron
   exec('npm list electron --dev', (err, stdout) => {
     if (err) {
       DEFAULT_OPTS.version = '1.2.0';
     } else {
       DEFAULT_OPTS.version = stdout.split('electron@')[1].replace(/\s/g, '');
     }
-
-    startPack();
   });
 }
 
+startPack();
 
 /**
  * @desc Execute the webpack build process on given config object
@@ -105,7 +100,7 @@ async function startPack() {
     // Start the packing process
     if (shouldBuildAll) {
       // build for all platforms
-      const archs = ['ia32', 'x64'];
+      const archs = ['ia32', 'x64', 'armv7l'];
       const platforms = ['linux', 'win32', 'darwin'];
 
       platforms.forEach(plat => {
@@ -132,22 +127,12 @@ async function startPack() {
 function pack(plat, arch, cb) {
   // there is no darwin ia32 electron
   if (plat === 'darwin' && arch === 'ia32') return;
+  // armv7l does not exist on any platform but linux
+  if (plat !== 'linux' && arch === 'armv7l') return;
 
-  const iconObj = {
-    icon: DEFAULT_OPTS.icon + (() => {
-      let extension = '.png';
-      if (plat === 'darwin') extension = '.icns';
-      if (plat === 'win32') extension = '.ico';
-
-      return extension;
-    })()
-  };
-
-  const opts = Object.assign({}, DEFAULT_OPTS, iconObj, {
+  const opts = Object.assign({}, DEFAULT_OPTS, {
     platform: plat,
-    arch,
-    prune: true,
-    'app-version': pkg.version || DEFAULT_OPTS.version,
+    arch: arch,
     out: `release/${plat}-${arch}`
   });
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "devtron": "^1.4.0",
     "electron": "^1.4.4",
     "electron-devtools-installer": "^2.0.1",
-    "electron-packager": "^8.1.0",
+    "electron-packager": "^8.2.0",
     "electron-rebuild": "^1.3.0",
     "enzyme": "^2.5.1",
     "eslint": "^3.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2128,10 +2128,6 @@ deep-eql@^0.1.3:
   dependencies:
     type-detect "0.1.1"
 
-deep-equal@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
-
 deep-extend@~0.4.0:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.1.tgz#efe4113d08085f4e6f9687759810f807469e2253"
@@ -2393,9 +2389,9 @@ electron-osx-sign@^0.3.0:
     minimist "^1.1.1"
     run-series "^1.1.1"
 
-electron-packager@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/electron-packager/-/electron-packager-8.1.0.tgz#90979bd870709ec4537a81ed6d6e6922968f878c"
+electron-packager@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/electron-packager/-/electron-packager-8.2.0.tgz#b5392816ecf927d6a41b7fb29f063e7dbd8d9818"
   dependencies:
     asar "^0.12.3"
     debug "^2.2.0"
@@ -2403,7 +2399,7 @@ electron-packager@^8.1.0:
     electron-osx-sign "^0.3.0"
     extract-zip "^1.0.3"
     fs-extra "^0.30.0"
-    get-package-info "^0.1.0"
+    get-package-info "^1.0.0"
     minimist "^1.1.1"
     plist "^2.0.0"
     rcedit "^0.7.0"
@@ -3033,6 +3029,12 @@ find-up@^1.0.0:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
 
+find-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.0.0.tgz#71e6dc2dad9222143cfc0fa5de7ab739e7320c05"
+  dependencies:
+    path-exists "^2.0.0"
+
 findup-sync@0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-0.4.2.tgz#a8117d0f73124f5a4546839579fe52d7129fb5e5"
@@ -3243,13 +3245,14 @@ generic-names@^1.0.1:
   dependencies:
     loader-utils "^0.2.11"
 
-get-package-info@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/get-package-info/-/get-package-info-0.1.0.tgz#f7754f13afdf9a64ee0ffd8c63bf806ed0f936d1"
+get-package-info@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/get-package-info/-/get-package-info-1.0.0.tgz#6432796563e28113cd9474dbbd00052985a4999c"
   dependencies:
     bluebird "^3.1.1"
+    debug "^2.2.0"
     lodash.get "^4.0.0"
-    resolve "^1.1.6"
+    read-pkg-up "^2.0.0"
 
 get-stdin@^4.0.1:
   version "4.0.1"
@@ -3525,14 +3528,14 @@ highlight.js@^9.3.0:
   version "9.7.0"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.7.0.tgz#e7a926bf3079c65b2ae50314878e456a009b4aac"
 
-history@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/history/-/history-2.1.2.tgz#4aa2de897a0e4867e4539843be6ecdb2986bfdec"
+history@^3.0.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/history/-/history-3.2.1.tgz#71c7497f4e6090363d19a6713bb52a1bfcdd99aa"
   dependencies:
-    deep-equal "^1.0.0"
-    invariant "^2.0.0"
-    query-string "^3.0.0"
-    warning "^2.0.0"
+    invariant "^2.2.1"
+    loose-envify "^1.2.0"
+    query-string "^4.2.2"
+    warning "^3.0.0"
 
 hoek@2.x.x:
   version "2.16.3"
@@ -4224,6 +4227,15 @@ load-json-file@^1.0.0, load-json-file@^1.1.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
+
+load-json-file@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^2.2.0"
+    pify "^2.0.0"
+    strip-bom "^3.0.0"
 
 loader-utils@^0.2.11, loader-utils@^0.2.3, loader-utils@^0.2.7, loader-utils@~0.2.2:
   version "0.2.16"
@@ -5427,6 +5439,12 @@ path-type@^1.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
+path-type@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
+  dependencies:
+    pify "^2.0.0"
+
 pbkdf2-compat@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz#b6e0c8fa99494d94e0511575802a59a5c142f288"
@@ -5855,13 +5873,7 @@ qs@6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.2.0.tgz#3b7848c03c2dece69a9522b0fae8c4126d745f3b"
 
-query-string@^3.0.0:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-3.0.3.tgz#ae2e14b4d05071d4e9b9eb4873c35b0dcd42e638"
-  dependencies:
-    strict-uri-encode "^1.0.0"
-
-query-string@^4.1.0:
+query-string@^4.1.0, query-string@^4.2.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.2.3.tgz#9f27273d207a25a8ee4c7b8c74dcd45d556db822"
   dependencies:
@@ -5940,11 +5952,11 @@ react-router-redux@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/react-router-redux/-/react-router-redux-4.0.6.tgz#10cf98dce911d7dd912a05bdb07fee4d3c563dee"
 
-react-router@^2.8.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-2.8.1.tgz#73e9491f6ceb316d0f779829081863e378ee4ed7"
+react-router@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-3.0.0.tgz#3f313e4dbaf57048c48dd0a8c3cac24d93667dff"
   dependencies:
-    history "^2.1.2"
+    history "^3.0.0"
     hoist-non-react-statics "^1.2.0"
     invariant "^2.2.1"
     loose-envify "^1.2.0"
@@ -6022,6 +6034,13 @@ read-pkg-up@^1.0.1:
     find-up "^1.0.0"
     read-pkg "^1.0.0"
 
+read-pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"
+  dependencies:
+    find-up "^2.0.0"
+    read-pkg "^2.0.0"
+
 read-pkg@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
@@ -6029,6 +6048,14 @@ read-pkg@^1.0.0:
     load-json-file "^1.0.0"
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
+
+read-pkg@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-2.0.0.tgz#8ef1c0623c6a6db0dc6713c4bfac46332b2368f8"
+  dependencies:
+    load-json-file "^2.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^2.0.0"
 
 read@~1.0.1, read@~1.0.7, read@1:
   version "1.0.7"
@@ -7272,12 +7299,6 @@ vm-browserify@0.0.4:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
   dependencies:
     indexof "0.0.1"
-
-warning@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-2.1.0.tgz#21220d9c63afc77a8c92111e011af705ce0c6901"
-  dependencies:
-    loose-envify "^1.0.0"
 
 warning@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Electron Packager [8.0.0](https://github.com/electron-userland/electron-packager/releases/tag/v8.0.0) was released today, which provides saner defaults, among other new features. This upgrades `electron-packager` and removes now unnecessary API options.
