### PR TITLE
Adding optional flowtype annotation checks with Babel

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,13 @@
 {
   "presets": ["es2015", "stage-0", "react"],
-  "plugins": ["add-module-exports"],
+  "plugins": [
+    "add-module-exports",
+    ["typecheck", {
+      "disable": {
+        "production": true
+      }
+    }]
+  ],
   "env": {
     "production": {
       "presets": ["react-optimize"],

--- a/.babelrc
+++ b/.babelrc
@@ -1,22 +1,14 @@
 {
   "presets": ["es2015", "stage-0", "react"],
-  "plugins": [
-    "add-module-exports",
-    ["typecheck", {
-      "disable": {
-        "production": true
-      }
-    }]
-  ],
+  "plugins": ["add-module-exports"],
   "env": {
     "production": {
       "presets": ["react-optimize"],
-      "plugins": [
-        "babel-plugin-dev-expression"
-      ]
+      "plugins": ["babel-plugin-dev-expression"]
     },
     "development": {
-      "presets": ["react-hmre"]
+      "presets": ["react-hmre"],
+      "plugins": ["tcomb"]
     },
     "test": {
       "plugins": [

--- a/README.md
+++ b/README.md
@@ -167,6 +167,9 @@ Then, use git to merge some latest commits:
 git pull upstream master
 ```
 
+## Type Annotations
+Optionally annotate your code with types. Use [Facebook's Flow](https://flowtype.org) or [tcomb types](https://github.com/gcanti/babel-plugin-tcomb-boilerplate) to optionally and gradually add type annotations to function arguments and return values. If you don't want to add type checking, just don't add types. Type checks are turned off during production mode.
+
 ## Native-like UI
 
 If you want to have native-like User Interface (OS X El Capitan and Windows 10), [react-desktop](https://github.com/gabrielbull/react-desktop) may perfect suit for you.

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "sinon": "^1.17.5",
     "spectron": "^3.3.0",
     "style-loader": "^0.13.1",
+    "tcomb": "^3.2.13",
     "webpack": "^1.13.2",
     "webpack-dev-middleware": "^1.6.1",
     "webpack-hot-middleware": "^2.12.2",
@@ -108,8 +109,7 @@
     "react-router-redux": "^4.0.5",
     "redux": "^3.5.2",
     "redux-thunk": "^2.1.0",
-    "source-map-support": "^0.4.2",
-    "tcomb": "^3.2.13"
+    "source-map-support": "^0.4.2"
   },
   "devEngines": {
     "node": "4.x || 5.x || 6.x",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "babel-loader": "^6.2.5",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-dev-expression": "^0.2.1",
+    "babel-plugin-typecheck": "^3.9.0",
     "babel-plugin-webpack-loaders": "^0.7.1",
     "babel-polyfill": "^6.13.0",
     "babel-preset-es2015": "^6.14.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "babel-loader": "^6.2.5",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-dev-expression": "^0.2.1",
-    "babel-plugin-typecheck": "^3.9.0",
+    "babel-plugin-tcomb": "^0.3.12",
     "babel-plugin-webpack-loaders": "^0.7.1",
     "babel-polyfill": "^6.13.0",
     "babel-preset-es2015": "^6.14.0",
@@ -108,7 +108,8 @@
     "react-router-redux": "^4.0.5",
     "redux": "^3.5.2",
     "redux-thunk": "^2.1.0",
-    "source-map-support": "^0.4.2"
+    "source-map-support": "^0.4.2",
+    "tcomb": "^3.2.13"
   },
   "devEngines": {
     "node": "4.x || 5.x || 6.x",


### PR DESCRIPTION
I've really enjoyed adding Flow type annotations to build apps (https://flowtype.org). It saves me from so many little errors and it helps document functions by specifying their argument types and return types.

Here is an example:
```
function add(num1: number, num2: number): number {
  return num1 + num2;
}
const x: number = add(3, '0');
console.log('x: ', x);   
```
The above example returns 30 instead of 0. Flow will catch things like this. Flow is becoming very powerful, even allowing you to specify possible values for a argument or return value.  This PR allows people to gradually add type annotations if they want it. If they don't use or know about type annotations, they don't have to change anything. Types annotations are only checked during dev, not production. 


