### PR TITLE
Enabling use of async/await in renderer

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -10,6 +10,17 @@ import './app.global.css';
 const store = configureStore();
 const history = syncHistoryWithStore(hashHistory, store);
 
+function sleep(ms = 0) {
+  return new Promise(r => setTimeout(r, ms));
+}
+async function asyncTest() {
+  console.log('a');
+  await sleep(3000);
+  console.log('b');
+}
+asyncTest();
+
+
 render(
   <Provider store={store}>
     <Router history={history} routes={routes} />

--- a/app/index.js
+++ b/app/index.js
@@ -10,17 +10,6 @@ import './app.global.css';
 const store = configureStore();
 const history = syncHistoryWithStore(hashHistory, store);
 
-function sleep(ms = 0) {
-  return new Promise(r => setTimeout(r, ms));
-}
-async function asyncTest() {
-  console.log('a');
-  await sleep(3000);
-  console.log('b');
-}
-asyncTest();
-
-
 render(
   <Provider store={store}>
     <Router history={history} routes={routes} />

--- a/webpack.config.development.js
+++ b/webpack.config.development.js
@@ -12,6 +12,7 @@ export default merge(baseConfig, {
 
   entry: [
     `webpack-hot-middleware/client?path=http://localhost:${port}/__webpack_hmr`,
+    'babel-polyfill',
     './app/index'
   ],
 

--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -6,7 +6,10 @@ import baseConfig from './webpack.config.base';
 const config = merge(baseConfig, {
   devtool: 'cheap-module-source-map',
 
-  entry: './app/index',
+  entry: [
+    'babel-polyfill',
+    './app/index'
+  ],
 
   output: {
     publicPath: '../dist/'


### PR DESCRIPTION
This adds the babel-polyfill to the entry of dev and production webpack configs to allow people to use async/await in their app. 

For an example async/await function, add this anywhere in the renderer code:
```
function sleep(ms = 0) {
  return new Promise(r => setTimeout(r, ms));
}
async function asyncTest() {
  console.log('a');
  await sleep(3000);
  console.log('b');
}
asyncTest();
```