### PR TITLE
Adding an externals example using bootstrap in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ $ set UPGRADE_EXTENSIONS=1 && npm run dev
 
 ## Externals
 
-If you use any 3rd party libraries which can't be built with webpack, you must list them in your `webpack.config.base.js`：
+If you use any 3rd party libraries which can't or won't be built with webpack, you must list them in your `webpack.config.base.js`：
 
 ```javascript
 externals: [
@@ -87,7 +87,19 @@ externals: [
 ]
 ```
 
-You can find those lines in the file.
+For a common example, to install Bootstrap, `npm i --save bootstrap` and link them in the head of app.html
+
+```html
+<link rel="stylesheet" href="../node_modules/bootstrap/dist/css/bootstrap.css" />
+<link rel="image/svg+xml" href="../node_modules/bootstrap/dist/fonts/glyphicons-halflings-regular.eot" />
+...
+```
+
+Make sure to list bootstrap in externals in `webpack.config.base.js` or the app won't include them in the package:
+```js
+externals: ['bootstrap']
+```
+ 
 
 
 ## CSS Modules


### PR DESCRIPTION
This is a readme-only PR that explains a little more how to use `externals` in the `webpack.config.base.js` file. In retrospect I see how the original documentation explains it, but not at all obvious when I was debugging. Especially with how `ignore` is set up in `package.js`:
```js
  ignore: [
    '^/test($|/)',
    '^/release($|/)',
    '^/main.development.js'
  ].concat(devDeps.map(name => `/node_modules/${name}($|/)`))
  .concat(
    deps.filter(name => !electronCfg.externals.includes(name))
      .map(name => `/node_modules/${name}($|/)`)
  )
```
 I gave a little more context (the app won't include them during packaging) and what is likely a very common need - installing Bootstrap or some other css framework.

I know it's important to keep the readme a reasonable length for users but I think this is worth it. 

Now that I understand how things work I can close this issue: https://github.com/chentsulin/electron-react-boilerplate/issues/384