### PR TITLE
Default packageAlias is browser

### DIFF
--- a/webpack.config.electron.js
+++ b/webpack.config.electron.js
@@ -13,9 +13,9 @@ export default merge(baseConfig, {
   },
   
   resolve: {
-    packageAlias: "main"
+    packageAlias: 'main'
   },
-
+  
   plugins: [
     new webpack.optimize.UglifyJsPlugin({
       compressor: {

--- a/webpack.config.electron.js
+++ b/webpack.config.electron.js
@@ -11,6 +11,10 @@ export default merge(baseConfig, {
     path: __dirname,
     filename: './main.js'
   },
+  
+  resolve: {
+    packageAlias: "main"
+  },
 
   plugins: [
     new webpack.optimize.UglifyJsPlugin({


### PR DESCRIPTION
Fix the packageAlias. The default is browser. This causes problems when importing packages that have a browser vs main entrypoint. Like form-data (required by request).

Fixes https://github.com/chentsulin/electron-react-boilerplate/issues/385