### PR TITLE
Get electron version for build with a require rather than an exec npm

### DIFF
--- a/package.js
+++ b/package.js
@@ -62,15 +62,9 @@ if (version) {
   startPack();
 } else {
   // use the same version as the currently-installed electron-prebuilt
-  exec('npm list electron --dev', (err, stdout) => {
-    if (err) {
-      DEFAULT_OPTS.version = '1.2.0';
-    } else {
-      DEFAULT_OPTS.version = stdout.split('electron@')[1].replace(/\s/g, '');
-    }
-
-    startPack();
-  });
+  // eslint-disable-next-line global-require
+  DEFAULT_OPTS.version = require('electron/package.json').version;
+  startPack();
 }
 
 


### PR DESCRIPTION
For random and, most of the time, legit reasons (peer dependencies things, blabla), the `npm list electron --dev` command fails (very silently), ending up packaging the app with a totally different version than the installed prebuilt.
It's a error-prone behavior in my opinion (I got tricked).

There is 2 ways to fix it:
- make the error more noisy and make the packaging fails
- use a more robust method to get the prebuilt electron version

I chose the 2nd one here.