### PR TITLE
Update redux-devtools-extension use

### DIFF
--- a/app/store/configureStore.development.js
+++ b/app/store/configureStore.development.js
@@ -19,19 +19,21 @@ const logger = createLogger({
 
 const router = routerMiddleware(hashHistory);
 
-const enhancer = compose(
-  applyMiddleware(thunk, router, logger),
-  window.devToolsExtension ?
-    window.devToolsExtension({ actionCreators }) :
-    noop => noop
+// If Redux DevTools Extension is installed use it, otherwise use Redux compose
+/* eslint-disable no-underscore-dangle */
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ ?
+  window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
+    // Options: http://zalmoxisus.github.io/redux-devtools-extension/API/Arguments.html
+    actionCreators,
+  }) :
+  compose;
+/* eslint-enable no-underscore-dangle */
+const enhancer = composeEnhancers(
+  applyMiddleware(thunk, router, logger)
 );
 
 export default function configureStore(initialState) {
   const store = createStore(rootReducer, initialState, enhancer);
-
-  if (window.devToolsExtension) {
-    window.devToolsExtension.updateStore(store);
-  }
 
   if (module.hot) {
     module.hot.accept('../reducers', () =>


### PR DESCRIPTION
For [`redux-devtools-extension@2.7.0`](https://github.com/zalmoxisus/redux-devtools-extension/releases/tag/v2.7.0), the `window.devtoolsExtension` is ready to deprecated, replaced by `window.__REDUX_DEVTOOLS_EXTENSION__` and `window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__`.