### PR TITLE
Add flag option `start-hot` and apply env

### DIFF
--- a/server.js
+++ b/server.js
@@ -36,7 +36,7 @@ const server = app.listen(PORT, 'localhost', serverError => {
   }
 
   if (argv['start-hot']) {
-    spawn('npm', ['run', 'start-hot'], { stdio: 'inherit' })
+    spawn('npm', ['run', 'start-hot'], { env: process.env, stdio: 'inherit' })
       .on('close', code => process.exit(code))
       .on('error', spawnError => console.error(spawnError));
   }

--- a/server.js
+++ b/server.js
@@ -13,6 +13,8 @@ import { spawn } from 'child_process';
 
 import config from './webpack.config.development';
 
+const argv = require('minimist')(process.argv.slice(2));
+
 const app = express();
 const compiler = webpack(config);
 const PORT = process.env.PORT || 3000;
@@ -33,9 +35,11 @@ const server = app.listen(PORT, 'localhost', serverError => {
     return console.error(serverError);
   }
 
-  spawn('npm', ['run', 'start-hot'], { stdio: 'inherit' })
-    .on('close', code => process.exit(code))
-    .on('error', spawnError => console.error(spawnError));
+  if (argv['start-hot']) {
+    spawn('npm', ['run', 'start-hot'], { stdio: 'inherit' })
+      .on('close', code => process.exit(code))
+      .on('error', spawnError => console.error(spawnError));
+  }
 
   console.log(`Listening at http://localhost:${PORT}`);
 });


### PR DESCRIPTION
To #489

1. Add flag option `start-hot`
2. Apply env to `start-hot` mode of server.js, ensure `PORT`, `UPGRADE_EXTENSIONS` can be used for `start-hot`

/cc @amilajack 