### PR TITLE
Add cross platform support for `start-hot` mode in server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -36,7 +36,7 @@ const server = app.listen(PORT, 'localhost', serverError => {
   }
 
   if (argv['start-hot']) {
-    spawn('npm', ['run', 'start-hot'], { env: process.env, stdio: 'inherit' })
+    spawn('npm', ['run', 'start-hot'], { shell: true, env: process.env, stdio: 'inherit' })
       .on('close', code => process.exit(code))
       .on('error', spawnError => console.error(spawnError));
   }


### PR DESCRIPTION
We need use `cmd /c "{command}"` for spawn on Windows.

It looks we just left node 4 support, so I just add `shell: true` option. (it only support for node ^6)