### PR TITLE
add explanation on npm run build, start and test-e2e

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,22 @@ To package apps with options:
 $ npm run package -- --[option]
 ```
 
+## Further commands
+
+To run the application without packaging run
+
+```bash
+$ npm run build
+$ npm start
+```
+
+To run End-to-End Test
+
+```bash
+$ npm run build
+$ npm run test-e2e
+```
+
 #### Options
 
 See [electron-builder CLI Usage](https://github.com/electron-userland/electron-builder#cli-usage)


### PR DESCRIPTION
First of all, thanks for all your great work! We started to build our electron app based on your boilerplate: https://github.com/Serverless/dashboard

One thing that my team & I struggled with were the purpose of several command e.g. `npm run build` and I opened an issue here: https://github.com/chentsulin/electron-react-boilerplate/issues/532

In order to avoid confusion in the future I propose this addition to the README. As an alternative we could add another directory docs containing a markdown file explaining all the commands and how to use them in combination.