### PR TITLE
Set line endings to use LF instead of auto (git)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
-* text=auto
+* text eol=lf
+*.png binary
+*.ico binary
+*.icns binary


### PR DESCRIPTION
Currently on windows git will checkout the files with CRLF with default settings. The eslint expects the line endings to be LF so this creates EsLint linebreak-style errors. Setting text to end of line to use LF and setting the image files as binaries solved this issue for me.