### PR TITLE
Adapt publicPath in webpack.config.production.js

### DIFF
--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -20,7 +20,7 @@ const config = validate(merge(baseConfig, {
 
   output: {
     path: path.join(__dirname, 'app/dist'),
-    publicPath: '../dist/'
+    publicPath: './dist/'
   },
 
   module: {


### PR DESCRIPTION
Seems that the publicPath was not set correctly. This prevented referenced files (e.g. with the url(...) parameter in less files) to load correctly.