### PR TITLE
Add electron-redux module

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -4,11 +4,13 @@ import { render } from 'react-dom';
 import { Provider } from 'react-redux';
 import { Router, hashHistory } from 'react-router';
 import { syncHistoryWithStore } from 'react-router-redux';
+import { getInitialStateRenderer } from 'electron-redux';
 import routes from './routes';
 import configureStore from './store/configureStore';
 import './app.global.css';
 
-const store = configureStore();
+const initialState = getInitialStateRenderer();
+const store = configureStore(initialState, 'renderer');
 const history = syncHistoryWithStore(hashHistory, store);
 
 render(

--- a/app/index.js
+++ b/app/index.js
@@ -10,7 +10,7 @@ import configureStore from './store/configureStore';
 import './app.global.css';
 
 const initialState = getInitialStateRenderer();
-const store = configureStore(initialState, 'renderer');
+const store = configureStore(initialState);
 const history = syncHistoryWithStore(hashHistory, store);
 
 render(

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -5,7 +5,7 @@ let menu;
 let template;
 let mainWindow = null;
 
-const store = configureStore({}, 'main');
+const store = configureStore();
 
 store.subscribe(() => {
   console.log('state from main process', store.getState());

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -1,8 +1,15 @@
 import { app, BrowserWindow, Menu, shell } from 'electron';
+import configureStore from './store/configureStore';
 
 let menu;
 let template;
 let mainWindow = null;
+
+const store = configureStore({}, 'main');
+
+store.subscribe(() => {
+  console.log('state from main process', store.getState());
+});
 
 if (process.env.NODE_ENV === 'production') {
   const sourceMapSupport = require('source-map-support'); // eslint-disable-line

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -1,11 +1,20 @@
 // @flow
 import { combineReducers } from 'redux';
 import { routerReducer as routing } from 'react-router-redux';
+import isRenderer from 'is-electron-renderer';
 import counter from './counter';
 
-const rootReducer = combineReducers({
+let reducers = {
   counter,
-  routing
-});
+};
+
+if (isRenderer) {
+  reducers = {
+    ...reducers,
+    routing
+  };
+}
+
+const rootReducer = combineReducers({ ...reducers });
 
 export default rootReducer;

--- a/app/store/configureStore.development.js
+++ b/app/store/configureStore.development.js
@@ -10,12 +10,13 @@ import {
   replayActionMain,
   replayActionRenderer,
 } from 'electron-redux';
+import isRenderer from 'is-electron-renderer';
 import rootReducer from '../reducers';
 
 import * as counterActions from '../actions/counter';
 
-export default (initialState: Object, scope = 'main') => {
-  console.log('initialState', initialState, scope);
+export default (initialState: Object) => {
+  const isMain = !isRenderer;
   // Redux Configuration
   let middleware = [];
   const enhancers = [];
@@ -24,7 +25,7 @@ export default (initialState: Object, scope = 'main') => {
   middleware.push(thunk);
 
   // Logging Middleware
-  if (scope === 'main') {
+  if (isMain) {
     const logger = createLogger({
       level: 'info',
       collapsed: true
@@ -33,14 +34,14 @@ export default (initialState: Object, scope = 'main') => {
   }
 
   // Router Middleware
-  if (scope === 'renderer') {
+  if (isRenderer) {
     const router = routerMiddleware(hashHistory);
     middleware.push(router);
   }
 
   // Redux DevTools Configuration
   let composeEnhancers = compose;
-  if (scope === 'renderer') {
+  if (isRenderer) {
     const actionCreators = {
       ...counterActions,
       push,
@@ -57,13 +58,13 @@ export default (initialState: Object, scope = 'main') => {
   }
 
   // Electron Redux Configuration
-  if (scope === 'renderer') {
+  if (isRenderer) {
     middleware = [
       forwardToMain,
       ...middleware,
     ];
   }
-  if (scope === 'main') {
+  if (isMain) {
     middleware = [
       triggerAlias,
       ...middleware,
@@ -84,7 +85,7 @@ export default (initialState: Object, scope = 'main') => {
     );
   }
 
-  if (scope === 'main') {
+  if (isMain) {
     replayActionMain(store);
   } else {
     replayActionRenderer(store);

--- a/app/store/configureStore.development.js
+++ b/app/store/configureStore.development.js
@@ -8,18 +8,29 @@ import rootReducer from '../reducers';
 import * as counterActions from '../actions/counter';
 
 export default (initialState: Object) => {
-  const actionCreators = {
-    ...counterActions,
-    push,
-  };
+  // Redux Configuration
+  const middleware = [];
+  const enhancers = [];
 
+  // Thunk Middleware
+  middleware.push(thunk);
+
+  // Logging Middleware
   const logger = createLogger({
     level: 'info',
     collapsed: true
   });
+  middleware.push(logger);
 
+  // Router Middleware
   const router = routerMiddleware(hashHistory);
+  middleware.push(router);
 
+  // Redux DevTools Configuration
+  const actionCreators = {
+    ...counterActions,
+    push,
+  };
   // If Redux DevTools Extension is installed use it, otherwise use Redux compose
   /* eslint-disable no-underscore-dangle */
   const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ ?
@@ -29,10 +40,12 @@ export default (initialState: Object) => {
     }) :
     compose;
   /* eslint-enable no-underscore-dangle */
-  const enhancer = composeEnhancers(
-    applyMiddleware(thunk, router, logger)
-  );
 
+  // Apply Middleware & Compose Enhancers
+  enhancers.push(applyMiddleware(...middleware));
+  const enhancer = composeEnhancers(...enhancers);
+
+  // Create Store
   const store = createStore(rootReducer, initialState, enhancer);
 
   if (module.hot) {

--- a/app/store/configureStore.development.js
+++ b/app/store/configureStore.development.js
@@ -3,43 +3,73 @@ import thunk from 'redux-thunk';
 import { hashHistory } from 'react-router';
 import { routerMiddleware, push } from 'react-router-redux';
 import createLogger from 'redux-logger';
+import {
+  forwardToMain,
+  forwardToRenderer,
+  triggerAlias,
+  replayActionMain,
+  replayActionRenderer,
+} from 'electron-redux';
 import rootReducer from '../reducers';
 
 import * as counterActions from '../actions/counter';
 
-export default (initialState: Object) => {
+export default (initialState: Object, scope = 'main') => {
+  console.log('initialState', initialState, scope);
   // Redux Configuration
-  const middleware = [];
+  let middleware = [];
   const enhancers = [];
 
   // Thunk Middleware
   middleware.push(thunk);
 
   // Logging Middleware
-  const logger = createLogger({
-    level: 'info',
-    collapsed: true
-  });
-  middleware.push(logger);
+  if (scope === 'main') {
+    const logger = createLogger({
+      level: 'info',
+      collapsed: true
+    });
+    middleware.push(logger);
+  }
 
   // Router Middleware
-  const router = routerMiddleware(hashHistory);
-  middleware.push(router);
+  if (scope === 'renderer') {
+    const router = routerMiddleware(hashHistory);
+    middleware.push(router);
+  }
 
   // Redux DevTools Configuration
-  const actionCreators = {
-    ...counterActions,
-    push,
-  };
-  // If Redux DevTools Extension is installed use it, otherwise use Redux compose
-  /* eslint-disable no-underscore-dangle */
-  const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ ?
-    window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
-      // Options: http://zalmoxisus.github.io/redux-devtools-extension/API/Arguments.html
-      actionCreators,
-    }) :
-    compose;
-  /* eslint-enable no-underscore-dangle */
+  let composeEnhancers = compose;
+  if (scope === 'renderer') {
+    const actionCreators = {
+      ...counterActions,
+      push,
+    };
+    // If Redux DevTools Extension is installed use it, otherwise use Redux compose
+    /* eslint-disable no-underscore-dangle */
+    composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ ?
+      window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
+        // Options: http://zalmoxisus.github.io/redux-devtools-extension/API/Arguments.html
+        actionCreators,
+      }) :
+      compose;
+    /* eslint-enable no-underscore-dangle */
+  }
+
+  // Electron Redux Configuration
+  if (scope === 'renderer') {
+    middleware = [
+      forwardToMain,
+      ...middleware,
+    ];
+  }
+  if (scope === 'main') {
+    middleware = [
+      triggerAlias,
+      ...middleware,
+      forwardToRenderer,
+    ];
+  }
 
   // Apply Middleware & Compose Enhancers
   enhancers.push(applyMiddleware(...middleware));
@@ -48,10 +78,16 @@ export default (initialState: Object) => {
   // Create Store
   const store = createStore(rootReducer, initialState, enhancer);
 
-  if (module.hot) {
+  if (!process.env.NODE_ENV && module.hot) {
     module.hot.accept('../reducers', () =>
       store.replaceReducer(require('../reducers')) // eslint-disable-line global-require
     );
+  }
+
+  if (scope === 'main') {
+    replayActionMain(store);
+  } else {
+    replayActionRenderer(store);
   }
 
   return store;

--- a/app/store/configureStore.development.js
+++ b/app/store/configureStore.development.js
@@ -7,32 +7,32 @@ import rootReducer from '../reducers';
 
 import * as counterActions from '../actions/counter';
 
-const actionCreators = {
-  ...counterActions,
-  push,
-};
+export default (initialState: Object) => {
+  const actionCreators = {
+    ...counterActions,
+    push,
+  };
 
-const logger = createLogger({
-  level: 'info',
-  collapsed: true
-});
+  const logger = createLogger({
+    level: 'info',
+    collapsed: true
+  });
 
-const router = routerMiddleware(hashHistory);
+  const router = routerMiddleware(hashHistory);
 
-// If Redux DevTools Extension is installed use it, otherwise use Redux compose
-/* eslint-disable no-underscore-dangle */
-const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ ?
-  window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
-    // Options: http://zalmoxisus.github.io/redux-devtools-extension/API/Arguments.html
-    actionCreators,
-  }) :
-  compose;
-/* eslint-enable no-underscore-dangle */
-const enhancer = composeEnhancers(
-  applyMiddleware(thunk, router, logger)
-);
+  // If Redux DevTools Extension is installed use it, otherwise use Redux compose
+  /* eslint-disable no-underscore-dangle */
+  const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ ?
+    window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
+      // Options: http://zalmoxisus.github.io/redux-devtools-extension/API/Arguments.html
+      actionCreators,
+    }) :
+    compose;
+  /* eslint-enable no-underscore-dangle */
+  const enhancer = composeEnhancers(
+    applyMiddleware(thunk, router, logger)
+  );
 
-export default function configureStore(initialState: Object) {
   const store = createStore(rootReducer, initialState, enhancer);
 
   if (module.hot) {
@@ -42,4 +42,4 @@ export default function configureStore(initialState: Object) {
   }
 
   return store;
-}
+};

--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
   },
   "dependencies": {
     "electron-debug": "^1.1.0",
+    "electron-redux": "^1.2.3",
     "font-awesome": "^4.7.0",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "electron-debug": "^1.1.0",
     "electron-redux": "^1.2.3",
     "font-awesome": "^4.7.0",
+    "is-electron-renderer": "^2.0.1",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
     "react-redux": "^4.4.6",


### PR DESCRIPTION
This uses the proposed changed in PR #602. 
I have the need for syncing the state between main and renderer, so this is my first pass. Based on the discussion from Issue #108 I decided to try https://github.com/hardchor/electron-redux/ first. I may do another PR for redux-electron-store and an alternative.

@burkhardr can you look over this and see if I got any of the implementation wrong? I based it on your timesheets repo.