### PR TITLE
add build productName

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "cleanup": "mop -v"
   },
   "build": {
+    "productName": "ElectronReact",
     "appId": "org.develar.ElectronReact",
     "category": "public.app-category.tools",
     "dmg": {


### PR DESCRIPTION
The build productName is used for the app distributables... suggest to add it here so other people can easily change it without digging through the docs!