### PR TITLE
Temporary fix #635, add es2015-classes / class-properties only for dev

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
-	"presets": [
-    ["env", {"targets": { "node": 6 }, "useBuiltIns": true }],
+  "presets": [
+    ["env", { "targets": { "node": 6 }, "useBuiltIns": true }],
     "stage-0",
     "react"
   ],
@@ -11,7 +11,11 @@
       "plugins": ["babel-plugin-dev-expression"]
     },
     "development": {
-			"plugins": ["tcomb"],
+      "plugins": [
+        "transform-class-properties",
+        "transform-es2015-classes",
+        "tcomb"
+      ],
       "presets": ["react-hmre"]
     },
     "test": {


### PR DESCRIPTION
Temporary fix #635.

Add `transform-es2015-classes` / `transform-class-properties` plugins only on development, until https://github.com/gaearon/react-hot-loader/issues/313 fix and we migrated to RHL v3 (#421).

__*NOTE*__ `transform-es2015-classes` is included in `babel-preset-env`, `transform-class-properties` is included in `babel-preset-stage-0`, so we don't need add to `package.json`.