### PR TITLE
Adding missing dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,8 @@
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-dev-expression": "^0.2.1",
     "babel-plugin-tcomb": "^0.3.24",
+    "babel-plugin-transform-class-properties": "^6.19.0",
+    "babel-plugin-transform-es2015-classes": "^6.18.0",
     "babel-plugin-webpack-loaders": "^0.8.0",
     "babel-polyfill": "^6.20.0",
     "babel-preset-env": "^1.1.6",


### PR DESCRIPTION
babel-plugin-transform-class-properties and babel-plugin-transform-es2015-classes are specified in `.babelrc` but were not in dev dependencies

I assume this works fine with npm@3 and yarn, because they have flat dependency trees. However, these packages should be in dev deps if they are used.

I noticed this when I was checking a really old issue created at pnpm https://github.com/rstacruz/pnpm/issues/79. By the way, I have good news! I worked the last 2 months on a complete rewrite of pnpm and with the latest pnpm@0.48.0, electron-react-boilerplate works with no issues.

This is the only issue, that these 2 deps are not in dev deps