### PR TITLE
Fix installExtensions

### DIFF
--- a/app/main.development.js
+++ b/app/main.development.js
@@ -35,7 +35,7 @@ const installExtensions = async () => {
     // TODO: Use async interation statement.
     //       Waiting on https://github.com/tc39/proposal-async-iteration
     //       Promises will fail silently, which isn't what we want in development
-    Promise
+    return Promise
       .all(extensions.map(name => installer.default(installer[name], forceDownload)))
       .catch(console.log);
   }


### PR DESCRIPTION
We should waiting for extensions installation, otherwise content script will not correctly load on renderer process when we use `forceDownload`.

This is fixing recent changes. (from [#651](https://github.com/chentsulin/electron-react-boilerplate/commit/470d082b9e26edc2075d89eac9008ca53a642a65#diff-4fa54749a138460ad8f3583b662fafeaR38))