### PR TITLE
Fix `babili-wepack-plugin` options for 0.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "babel-preset-react-optimize": "^1.0.1",
     "babel-preset-stage-0": "^6.22.0",
     "babel-register": "^6.22.0",
-    "babili-webpack-plugin": "^0.0.8",
+    "babili-webpack-plugin": "^0.0.9",
     "boiler-room-custodian": "^0.6.1",
     "chai": "^3.5.0",
     "concurrently": "^3.1.0",

--- a/webpack.config.electron.js
+++ b/webpack.config.electron.js
@@ -25,7 +25,7 @@ export default validate(merge(baseConfig, {
      */
     new BabiliPlugin({
       // Disable deadcode until https://github.com/babel/babili/issues/385 fixed
-      babili: ['babel-preset-babili', { deadcode: false }],
+      deadcode: false,
     }),
 
     /**

--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -81,7 +81,7 @@ export default validate(merge(baseConfig, {
      */
     new BabiliPlugin({
       // Disable deadcode until https://github.com/babel/babili/issues/385 fixed
-      babili: ['babel-preset-babili', { deadcode: false }],
+      deadcode: false,
     }),
 
     new ExtractTextPlugin('style.css', { allChunks: true }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1363,9 +1363,9 @@ babel-types@^6.15.0, babel-types@^6.19.0, babel-types@^6.22.0, babel-types@^6.3.
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babili-webpack-plugin@^0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/babili-webpack-plugin/-/babili-webpack-plugin-0.0.8.tgz#6c6ef2624320d324014edc4265c6f810d91d013e"
+babili-webpack-plugin@^0.0.9:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/babili-webpack-plugin/-/babili-webpack-plugin-0.0.9.tgz#9bdb3041cea93cc38259e140e1bd7741f4877337"
   dependencies:
     babel-core "^6.22.1"
     babel-preset-babili "^0.0.10"


### PR DESCRIPTION
v0.0.9 breaks options usage, [see this change](https://github.com/boopathi/babili-webpack-plugin/commit/4dff17d7268849432624d659ae86a7a224859298).

Closes #700.