### PR TITLE
Disable `no-multi-assign` for eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,4 @@
-flow-typed/**/*.js
+flow-typed/
+app/dist/
+app/main.js
+node_modules

--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,7 @@
     "import/no-extraneous-dependencies": "off",
     "no-console": 0,
     "no-use-before-define": "off",
+    "no-multi-assign": 0,
     "promise/param-names": 2,
     "promise/always-return": 2,
     "promise/catch-or-return": 2,


### PR DESCRIPTION
It seems have `no-multi-assign` error __only__ on Windows ([AppVeyor build](https://ci.appveyor.com/project/chentsulin/electron-react-boilerplate/build/1384/job/p2svljseu4eoa7l6#L1613)), I don't know why, I've tried on my Windows machine. ¯\\\_(ツ)_/¯

Also add bundle files to eslintignore.