### PR TITLE
Refactoring code for menu for easier changes

### DIFF
--- a/app/main.development.js
+++ b/app/main.development.js
@@ -1,3 +1,4 @@
+// @flow
 import { app, BrowserWindow } from 'electron';
 import MenuBuilder from './menu';
 
@@ -52,8 +53,8 @@ app.on('ready', async () => {
   mainWindow.loadURL(`file://${__dirname}/app.html`);
 
   mainWindow.webContents.on('did-finish-load', () => {
-    mainWindow.show();
-    mainWindow.focus();
+    mainWindow.show(); // eslint-disable-line
+    mainWindow.focus(); // eslint-disable-line
   });
 
   mainWindow.on('closed', () => {

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -53,8 +53,11 @@ app.on('ready', async () => {
   mainWindow.loadURL(`file://${__dirname}/app.html`);
 
   mainWindow.webContents.on('did-finish-load', () => {
-    mainWindow.show(); // eslint-disable-line
-    mainWindow.focus(); // eslint-disable-line
+    if (!mainWindow) {
+      throw new Error('"mainWindow" is not defined');
+    }
+    mainWindow.show();
+    mainWindow.focus();
   });
 
   mainWindow.on('closed', () => {

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -4,8 +4,6 @@ import MenuBuilder from './menu';
 let menu;
 let mainWindow = null;
 
-const urlDriveHome = 'https://drive.google.com';
-
 if (process.env.NODE_ENV === 'production') {
   const sourceMapSupport = require('source-map-support'); // eslint-disable-line
   sourceMapSupport.install();

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -1,8 +1,10 @@
-import { app, BrowserWindow, Menu, shell } from 'electron';
+import { app, BrowserWindow } from 'electron';
+import MenuBuilder from './menu';
 
 let menu;
-let template;
 let mainWindow = null;
+
+const urlDriveHome = 'https://drive.google.com';
 
 if (process.env.NODE_ENV === 'production') {
   const sourceMapSupport = require('source-map-support'); // eslint-disable-line
@@ -42,6 +44,7 @@ const installExtensions = async () => {
 };
 
 app.on('ready', async () => {
+
   await installExtensions();
 
   mainWindow = new BrowserWindow({
@@ -61,217 +64,7 @@ app.on('ready', async () => {
     mainWindow = null;
   });
 
-  if (process.env.NODE_ENV === 'development') {
-    mainWindow.openDevTools();
-    mainWindow.webContents.on('context-menu', (e, props) => {
-      const { x, y } = props;
+  const menuBuilder = new MenuBuilder(mainWindow);
+  menu = menuBuilder.buildMenu(process.env.NODE_ENV, process.platform);
 
-      Menu.buildFromTemplate([{
-        label: 'Inspect element',
-        click() {
-          mainWindow.inspectElement(x, y);
-        }
-      }]).popup(mainWindow);
-    });
-  }
-
-  if (process.platform === 'darwin') {
-    template = [{
-      label: 'Electron',
-      submenu: [{
-        label: 'About ElectronReact',
-        selector: 'orderFrontStandardAboutPanel:'
-      }, {
-        type: 'separator'
-      }, {
-        label: 'Services',
-        submenu: []
-      }, {
-        type: 'separator'
-      }, {
-        label: 'Hide ElectronReact',
-        accelerator: 'Command+H',
-        selector: 'hide:'
-      }, {
-        label: 'Hide Others',
-        accelerator: 'Command+Shift+H',
-        selector: 'hideOtherApplications:'
-      }, {
-        label: 'Show All',
-        selector: 'unhideAllApplications:'
-      }, {
-        type: 'separator'
-      }, {
-        label: 'Quit',
-        accelerator: 'Command+Q',
-        click() {
-          app.quit();
-        }
-      }]
-    }, {
-      label: 'Edit',
-      submenu: [{
-        label: 'Undo',
-        accelerator: 'Command+Z',
-        selector: 'undo:'
-      }, {
-        label: 'Redo',
-        accelerator: 'Shift+Command+Z',
-        selector: 'redo:'
-      }, {
-        type: 'separator'
-      }, {
-        label: 'Cut',
-        accelerator: 'Command+X',
-        selector: 'cut:'
-      }, {
-        label: 'Copy',
-        accelerator: 'Command+C',
-        selector: 'copy:'
-      }, {
-        label: 'Paste',
-        accelerator: 'Command+V',
-        selector: 'paste:'
-      }, {
-        label: 'Select All',
-        accelerator: 'Command+A',
-        selector: 'selectAll:'
-      }]
-    }, {
-      label: 'View',
-      submenu: (process.env.NODE_ENV === 'development') ? [{
-        label: 'Reload',
-        accelerator: 'Command+R',
-        click() {
-          mainWindow.webContents.reload();
-        }
-      }, {
-        label: 'Toggle Full Screen',
-        accelerator: 'Ctrl+Command+F',
-        click() {
-          mainWindow.setFullScreen(!mainWindow.isFullScreen());
-        }
-      }, {
-        label: 'Toggle Developer Tools',
-        accelerator: 'Alt+Command+I',
-        click() {
-          mainWindow.toggleDevTools();
-        }
-      }] : [{
-        label: 'Toggle Full Screen',
-        accelerator: 'Ctrl+Command+F',
-        click() {
-          mainWindow.setFullScreen(!mainWindow.isFullScreen());
-        }
-      }]
-    }, {
-      label: 'Window',
-      submenu: [{
-        label: 'Minimize',
-        accelerator: 'Command+M',
-        selector: 'performMiniaturize:'
-      }, {
-        label: 'Close',
-        accelerator: 'Command+W',
-        selector: 'performClose:'
-      }, {
-        type: 'separator'
-      }, {
-        label: 'Bring All to Front',
-        selector: 'arrangeInFront:'
-      }]
-    }, {
-      label: 'Help',
-      submenu: [{
-        label: 'Learn More',
-        click() {
-          shell.openExternal('http://electron.atom.io');
-        }
-      }, {
-        label: 'Documentation',
-        click() {
-          shell.openExternal('https://github.com/atom/electron/tree/master/docs#readme');
-        }
-      }, {
-        label: 'Community Discussions',
-        click() {
-          shell.openExternal('https://discuss.atom.io/c/electron');
-        }
-      }, {
-        label: 'Search Issues',
-        click() {
-          shell.openExternal('https://github.com/atom/electron/issues');
-        }
-      }]
-    }];
-
-    menu = Menu.buildFromTemplate(template);
-    Menu.setApplicationMenu(menu);
-  } else {
-    template = [{
-      label: '&File',
-      submenu: [{
-        label: '&Open',
-        accelerator: 'Ctrl+O'
-      }, {
-        label: '&Close',
-        accelerator: 'Ctrl+W',
-        click() {
-          mainWindow.close();
-        }
-      }]
-    }, {
-      label: '&View',
-      submenu: (process.env.NODE_ENV === 'development') ? [{
-        label: '&Reload',
-        accelerator: 'Ctrl+R',
-        click() {
-          mainWindow.webContents.reload();
-        }
-      }, {
-        label: 'Toggle &Full Screen',
-        accelerator: 'F11',
-        click() {
-          mainWindow.setFullScreen(!mainWindow.isFullScreen());
-        }
-      }, {
-        label: 'Toggle &Developer Tools',
-        accelerator: 'Alt+Ctrl+I',
-        click() {
-          mainWindow.toggleDevTools();
-        }
-      }] : [{
-        label: 'Toggle &Full Screen',
-        accelerator: 'F11',
-        click() {
-          mainWindow.setFullScreen(!mainWindow.isFullScreen());
-        }
-      }]
-    }, {
-      label: 'Help',
-      submenu: [{
-        label: 'Learn More',
-        click() {
-          shell.openExternal('http://electron.atom.io');
-        }
-      }, {
-        label: 'Documentation',
-        click() {
-          shell.openExternal('https://github.com/atom/electron/tree/master/docs#readme');
-        }
-      }, {
-        label: 'Community Discussions',
-        click() {
-          shell.openExternal('https://discuss.atom.io/c/electron');
-        }
-      }, {
-        label: 'Search Issues',
-        click() {
-          shell.openExternal('https://github.com/atom/electron/issues');
-        }
-      }]
-    }];
-    menu = Menu.buildFromTemplate(template);
-    mainWindow.setMenu(menu);
-  }
 });

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -41,7 +41,6 @@ const installExtensions = async () => {
 };
 
 app.on('ready', async () => {
-
   await installExtensions();
 
   mainWindow = new BrowserWindow({
@@ -62,6 +61,5 @@ app.on('ready', async () => {
   });
 
   const menuBuilder = new MenuBuilder(mainWindow);
-  menu = menuBuilder.buildMenu(process.env.NODE_ENV, process.platform);
-
+  menuBuilder.buildMenu(process.env.NODE_ENV, process.platform);
 });

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -61,5 +61,5 @@ app.on('ready', async () => {
   });
 
   const menuBuilder = new MenuBuilder(mainWindow);
-  menuBuilder.buildMenu(process.env.NODE_ENV, process.platform);
+  menuBuilder.buildMenu();
 });

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -1,7 +1,6 @@
 import { app, BrowserWindow } from 'electron';
 import MenuBuilder from './menu';
 
-let menu;
 let mainWindow = null;
 
 if (process.env.NODE_ENV === 'production') {

--- a/app/menu.js
+++ b/app/menu.js
@@ -1,3 +1,4 @@
+// @flow
 import { app, Menu, shell } from 'electron';
 
 export default class MenuBuilder {

--- a/app/menu.js
+++ b/app/menu.js
@@ -1,9 +1,10 @@
 // @flow
-import { app, Menu, shell } from 'electron';
+import { app, Menu, shell, BrowserWindow } from 'electron';
 
 export default class MenuBuilder {
+  mainWindow: BrowserWindow;
 
-  constructor(mainWindow) {
+  constructor(mainWindow: BrowserWindow) {
     this.mainWindow = mainWindow;
   }
 

--- a/app/menu.js
+++ b/app/menu.js
@@ -1,4 +1,4 @@
-import { BrowserWindow, Menu, shell } from 'electron';
+import { Menu, shell } from 'electron';
 
 export default class MenuBuilder {
 
@@ -16,8 +16,7 @@ export default class MenuBuilder {
 
     if (platform === 'darwin') {
       template = this.buildDarwinTemplate();
-    }
-    else {
+    } else {
       template = this.buildDefaultTemplate();
     }
 
@@ -51,7 +50,7 @@ export default class MenuBuilder {
         { label: 'Hide Others', accelerator: 'Command+Shift+H', selector: 'hideOtherApplications:' },
         { label: 'Show All', selector: 'unhideAllApplications:' },
         { type: 'separator' },
-        { label: 'Quit', accelerator: 'Command+Q', click: () => { this.app.quit() } }
+        { label: 'Quit', accelerator: 'Command+Q', click: () => { this.app.quit(); } }
       ]
     };
     const subMenuEdit = {
@@ -69,15 +68,15 @@ export default class MenuBuilder {
     const subMenuViewDev = {
       label: 'View',
       submenu: [
-        { label: 'Reload', accelerator: 'Command+R', click:() => { this.mainWindow.webContents.reload() } },
-        { label: 'Toggle Full Screen', accelerator: 'Ctrl+Command+F', click:() => { this.mainWindow.setFullScreen(!this.mainWindow.isFullScreen()) } },
-        { label: 'Toggle Developer Tools', accelerator: 'Alt+Command+I', click:() => { this.mainWindow.toggleDevTools() } }
+        { label: 'Reload', accelerator: 'Command+R', click: () => { this.mainWindow.webContents.reload(); } },
+        { label: 'Toggle Full Screen', accelerator: 'Ctrl+Command+F', click: () => { this.mainWindow.setFullScreen(!this.mainWindow.isFullScreen()); } },
+        { label: 'Toggle Developer Tools', accelerator: 'Alt+Command+I', click: () => { this.mainWindow.toggleDevTools(); } }
       ]
     };
     const subMenuViewProd = {
       label: 'View',
       submenu: [
-        { label: 'Toggle Full Screen', accelerator: 'Ctrl+Command+F', click:() => { this.mainWindow.setFullScreen(!this.mainWindow.isFullScreen()) } }
+        { label: 'Toggle Full Screen', accelerator: 'Ctrl+Command+F', click: () => { this.mainWindow.setFullScreen(!this.mainWindow.isFullScreen()); } }
       ]
     };
     const subMenuWindow = {
@@ -92,14 +91,14 @@ export default class MenuBuilder {
     const subMenuHelp = {
       label: 'Help',
       submenu: [
-        { label: 'Learn More', click() { shell.openExternal('http://electron.atom.io') } },
-        { label: 'Documentation', click() { shell.openExternal('https://github.com/atom/electron/tree/master/docs#readme') } },
-        { label: 'Community Discussions', click() { shell.openExternal('https://discuss.atom.io/c/electron') } },
-        { label: 'Search Issues', click() { shell.openExternal('https://github.com/atom/electron/issues') } }
+        { label: 'Learn More', click() { shell.openExternal('http://electron.atom.io'); } },
+        { label: 'Documentation', click() { shell.openExternal('https://github.com/atom/electron/tree/master/docs#readme'); } },
+        { label: 'Community Discussions', click() { shell.openExternal('https://discuss.atom.io/c/electron'); } },
+        { label: 'Search Issues', click() { shell.openExternal('https://github.com/atom/electron/issues'); } }
       ]
     };
 
-    const subMenuView = process.env.NODE_ENV === "development" ? subMenuViewDev : subMenuViewProd;
+    const subMenuView = process.env.NODE_ENV === 'development' ? subMenuViewDev : subMenuViewProd;
 
     return [
       subMenuAbout,
@@ -178,5 +177,3 @@ export default class MenuBuilder {
     return templateDefault;
   }
 }
-
-

--- a/app/menu.js
+++ b/app/menu.js
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, Menu, shell } from 'electron';
+import { BrowserWindow, Menu, shell } from 'electron';
 
 export default class MenuBuilder {
 
@@ -8,18 +8,17 @@ export default class MenuBuilder {
   }
 
   buildMenu(env, platform) {
-
     if (env === 'development') {
-      this._setupDevelopmentEnvironment();
+      this.setupDevelopmentEnvironment();
     }
 
     let template;
 
     if (platform === 'darwin') {
-      template = this._buildDarwinTemplate();
+      template = this.buildDarwinTemplate();
     }
     else {
-      template = this._buildDefaultTemplate();
+      template = this.buildDefaultTemplate();
     }
 
     const menu = Menu.buildFromTemplate(template);
@@ -28,7 +27,7 @@ export default class MenuBuilder {
     return menu;
   }
 
-  _setupDevelopmentEnvironment() {
+  setupDevelopmentEnvironment() {
     this.mainWindow.openDevTools();
     this.mainWindow.webContents.on('context-menu', (e, props) => {
       const { x, y } = props;
@@ -42,7 +41,7 @@ export default class MenuBuilder {
     });
   }
 
-  _buildDarwinTemplate() {
+  buildDarwinTemplate() {
     const subMenuAbout = {
       label: 'Electron',
       submenu: [
@@ -111,7 +110,7 @@ export default class MenuBuilder {
     ];
   }
 
-  _buildDefaultTemplate() {
+  buildDefaultTemplate() {
     const templateDefault = [{
       label: '&File',
       submenu: [{

--- a/app/menu.js
+++ b/app/menu.js
@@ -6,14 +6,14 @@ export default class MenuBuilder {
     this.mainWindow = mainWindow;
   }
 
-  buildMenu(env, platform) {
-    if (env === 'development') {
+  buildMenu() {
+    if (process.env.NODE_ENV === 'development') {
       this.setupDevelopmentEnvironment();
     }
 
     let template;
 
-    if (platform === 'darwin') {
+    if (process.platform === 'darwin') {
       template = this.buildDarwinTemplate();
     } else {
       template = this.buildDefaultTemplate();

--- a/app/menu.js
+++ b/app/menu.js
@@ -46,8 +46,10 @@ export default class MenuBuilder {
       label: 'Electron',
       submenu: [
         { label: 'About ElectronReact', selector: 'orderFrontStandardAboutPanel:' },
-        { type: 'separator' }, { label: 'Services', submenu: [] },
-        { type: 'separator' }, { label: 'Hide ElectronReact', accelerator: 'Command+H', selector: 'hide:' },
+        { type: 'separator' },
+        { label: 'Services', submenu: [] },
+        { type: 'separator' },
+        { label: 'Hide ElectronReact', accelerator: 'Command+H', selector: 'hide:' },
         { label: 'Hide Others', accelerator: 'Command+Shift+H', selector: 'hideOtherApplications:' },
         { label: 'Show All', selector: 'unhideAllApplications:' },
         { type: 'separator' },

--- a/app/menu.js
+++ b/app/menu.js
@@ -1,0 +1,183 @@
+import { app, BrowserWindow, Menu, shell } from 'electron';
+
+export default class MenuBuilder {
+
+  constructor(mainWindow, app) {
+    this.mainWindow = mainWindow;
+    this.app = app;
+  }
+
+  buildMenu(env, platform) {
+
+    if (env === 'development') {
+      this._setupDevelopmentEnvironment();
+    }
+
+    let template;
+
+    if (platform === 'darwin') {
+      template = this._buildDarwinTemplate();
+    }
+    else {
+      template = this._buildDefaultTemplate();
+    }
+
+    const menu = Menu.buildFromTemplate(template);
+    Menu.setApplicationMenu(menu);
+
+    return menu;
+  }
+
+  _setupDevelopmentEnvironment() {
+    this.mainWindow.openDevTools();
+    this.mainWindow.webContents.on('context-menu', (e, props) => {
+      const { x, y } = props;
+
+      Menu.buildFromTemplate([{
+        label: 'Inspect element',
+        click() {
+          this.mainWindow.inspectElement(x, y);
+        }
+      }]).popup(this.mainWindow);
+    });
+  }
+
+  _buildDarwinTemplate() {
+    const subMenuAbout = {
+      label: 'Electron',
+      submenu: [
+        { label: 'About ElectronReact', selector: 'orderFrontStandardAboutPanel:' },
+        { type: 'separator' }, { label: 'Services', submenu: [] },
+        { type: 'separator' }, { label: 'Hide ElectronReact', accelerator: 'Command+H', selector: 'hide:' },
+        { label: 'Hide Others', accelerator: 'Command+Shift+H', selector: 'hideOtherApplications:' },
+        { label: 'Show All', selector: 'unhideAllApplications:' },
+        { type: 'separator' },
+        { label: 'Quit', accelerator: 'Command+Q', click: () => { this.app.quit() } }
+      ]
+    };
+    const subMenuEdit = {
+      label: 'Edit',
+      submenu: [
+        { label: 'Undo', accelerator: 'Command+Z', selector: 'undo:' },
+        { label: 'Redo', accelerator: 'Shift+Command+Z', selector: 'redo:' },
+        { type: 'separator' },
+        { label: 'Cut', accelerator: 'Command+X', selector: 'cut:' },
+        { label: 'Copy', accelerator: 'Command+C', selector: 'copy:' },
+        { label: 'Paste', accelerator: 'Command+V', selector: 'paste:' },
+        { label: 'Select All', accelerator: 'Command+A', selector: 'selectAll:' }
+      ]
+    };
+    const subMenuViewDev = {
+      label: 'View',
+      submenu: [
+        { label: 'Reload', accelerator: 'Command+R', click:() => { this.mainWindow.webContents.reload() } },
+        { label: 'Toggle Full Screen', accelerator: 'Ctrl+Command+F', click:() => { this.mainWindow.setFullScreen(!this.mainWindow.isFullScreen()) } },
+        { label: 'Toggle Developer Tools', accelerator: 'Alt+Command+I', click:() => { this.mainWindow.toggleDevTools() } }
+      ]
+    };
+    const subMenuViewProd = {
+      label: 'View',
+      submenu: [
+        { label: 'Toggle Full Screen', accelerator: 'Ctrl+Command+F', click:() => { this.mainWindow.setFullScreen(!this.mainWindow.isFullScreen()) } }
+      ]
+    };
+    const subMenuWindow = {
+      label: 'Window',
+      submenu: [
+        { label: 'Minimize', accelerator: 'Command+M', selector: 'performMiniaturize:' },
+        { label: 'Close', accelerator: 'Command+W', selector: 'performClose:' },
+        { type: 'separator' },
+        { label: 'Bring All to Front', selector: 'arrangeInFront:' }
+      ]
+    };
+    const subMenuHelp = {
+      label: 'Help',
+      submenu: [
+        { label: 'Learn More', click() { shell.openExternal('http://electron.atom.io') } },
+        { label: 'Documentation', click() { shell.openExternal('https://github.com/atom/electron/tree/master/docs#readme') } },
+        { label: 'Community Discussions', click() { shell.openExternal('https://discuss.atom.io/c/electron') } },
+        { label: 'Search Issues', click() { shell.openExternal('https://github.com/atom/electron/issues') } }
+      ]
+    };
+
+    const subMenuView = process.env.NODE_ENV === "development" ? subMenuViewDev : subMenuViewProd;
+
+    return [
+      subMenuAbout,
+      subMenuEdit,
+      subMenuView,
+      subMenuWindow,
+      subMenuHelp
+    ];
+  }
+
+  _buildDefaultTemplate() {
+    const templateDefault = [{
+      label: '&File',
+      submenu: [{
+        label: '&Open',
+        accelerator: 'Ctrl+O'
+      }, {
+        label: '&Close',
+        accelerator: 'Ctrl+W',
+        click: () => {
+          this.mainWindow.close();
+        }
+      }]
+    }, {
+      label: '&View',
+      submenu: (process.env.NODE_ENV === 'development') ? [{
+        label: '&Reload',
+        accelerator: 'Ctrl+R',
+        click: () => {
+          this.mainWindow.webContents.reload();
+        }
+      }, {
+        label: 'Toggle &Full Screen',
+        accelerator: 'F11',
+        click: () => {
+          this.mainWindow.setFullScreen(!this.mainWindow.isFullScreen());
+        }
+      }, {
+        label: 'Toggle &Developer Tools',
+        accelerator: 'Alt+Ctrl+I',
+        click: () => {
+          this.mainWindow.toggleDevTools();
+        }
+      }] : [{
+        label: 'Toggle &Full Screen',
+        accelerator: 'F11',
+        click: () => {
+          this.mainWindow.setFullScreen(!this.mainWindow.isFullScreen());
+        }
+      }]
+    }, {
+      label: 'Help',
+      submenu: [{
+        label: 'Learn More',
+        click() {
+          shell.openExternal('http://electron.atom.io');
+        }
+      }, {
+        label: 'Documentation',
+        click() {
+          shell.openExternal('https://github.com/atom/electron/tree/master/docs#readme');
+        }
+      }, {
+        label: 'Community Discussions',
+        click() {
+          shell.openExternal('https://discuss.atom.io/c/electron');
+        }
+      }, {
+        label: 'Search Issues',
+        click() {
+          shell.openExternal('https://github.com/atom/electron/issues');
+        }
+      }]
+    }];
+
+    return templateDefault;
+  }
+}
+
+

--- a/app/menu.js
+++ b/app/menu.js
@@ -1,10 +1,9 @@
-import { Menu, shell } from 'electron';
+import { app, Menu, shell } from 'electron';
 
 export default class MenuBuilder {
 
-  constructor(mainWindow, app) {
+  constructor(mainWindow) {
     this.mainWindow = mainWindow;
-    this.app = app;
   }
 
   buildMenu(env, platform) {
@@ -50,7 +49,7 @@ export default class MenuBuilder {
         { label: 'Hide Others', accelerator: 'Command+Shift+H', selector: 'hideOtherApplications:' },
         { label: 'Show All', selector: 'unhideAllApplications:' },
         { type: 'separator' },
-        { label: 'Quit', accelerator: 'Command+Q', click: () => { this.app.quit(); } }
+        { label: 'Quit', accelerator: 'Command+Q', click: () => { app.quit(); } }
       ]
     };
     const subMenuEdit = {


### PR DESCRIPTION
When modifying the code for the menu I thought it would be a good idea to separate it from the main.development.file, add it to a class and break it down to make it easier for people to add changes  and customise menus in the future.