### PR TITLE
Prevent webpack.DefinePlugin from overriding process.env object

### DIFF
--- a/webpack.config.electron.js
+++ b/webpack.config.electron.js
@@ -34,9 +34,7 @@ export default merge(baseConfig, {
      * development checks
      */
     new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: JSON.stringify('production')
-      }
+      'process.env.NODE_ENV': JSON.stringify('production')
     })
   ],
 


### PR DESCRIPTION
Currently when production app is running, in the main process just one environment variable exists  - `NODE_ENV`. This change should prevent process.env object from being reset.