### PR TITLE
Adding plop support for ease of dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "package-win": "npm run build && build --win --x64",
     "package-linux": "npm run build && build --linux",
     "package-all": "npm run build && build -mwl",
-    "cleanup": "mop -v"
+    "cleanup": "mop -v",
+    "plop": "node ./node_modules/plop/src/plop.js"
   },
   "browserslist": "electron 1.4",
   "build": {

--- a/plopfile.js
+++ b/plopfile.js
@@ -1,9 +1,22 @@
 module.exports = function (plop) {
   // create your generators here
-  plop.setGenerator('basics', {
-    description: 'this is a skeleton plopfile',
-    prompts: [],
-    actions: []
+  plop.setGenerator('helper', {
+    description: 'Create a utils file',
+    prompts: [{
+      type: 'input',
+      name: 'name',
+      message: 'What is the name of your file?',
+      validate: function (value) {
+        if ((/.+/).test(value)) { return true; }
+        return 'name is required';
+      }
+    }],
+    actions: [{
+      type: 'add',
+      path: './app/utils/{{camelCase name}}.js',
+      templateFile: 'templates/helper.js',
+      abortOnFail: true
+    }]
   }),
 
   plop.setGenerator('component', {

--- a/plopfile.js
+++ b/plopfile.js
@@ -1,0 +1,94 @@
+module.exports = function (plop) {
+  // create your generators here
+  plop.setGenerator('basics', {
+    description: 'this is a skeleton plopfile',
+    prompts: [],
+    actions: []
+  }),
+
+  plop.setGenerator('component', {
+    description: 'Generate a new component',
+    prompts: [{
+      type: 'input',
+      name: 'name',
+      message: 'What is the name of your component?',
+      validate: function (value) {
+        if ((/.+/).test(value)) { return true; }
+        return 'name is required';
+      }
+    }, {
+        type: 'confirm',
+        name: 'stateless',
+        message: 'Is this a stateless component?'
+    }, {
+        type: 'confirm',
+        name: 'styled',
+        message: 'Is this component styled?'
+    }],
+
+    actions: function(data) {
+      var actions = [];
+
+      if(data.styled) {
+        actions = actions.concat([
+          {
+            type: 'add',
+            path: './app/components/{{properCase name}}.css',
+            templateFile: 'templates/style.css',
+            abortOnFail: true
+          }
+        ]);
+      }
+
+      if(data.stateless) {
+        actions = actions.concat([
+          {
+            type: 'add',
+            path: './app/components/{{properCase name}}.js',
+            templateFile: 'templates/stateless.js',
+            abortOnFail: true
+          }
+        ]);
+      } else {
+        actions = actions.concat([
+          {
+            type: 'add',
+            path: './app/components/{{properCase name}}.js',
+            templateFile: 'templates/stateful.js',
+            abortOnFail: true
+          }, {
+            type: 'add',
+            path: './app/actions/{{camelCase name}}.js',
+            templateFile: 'templates/actions.js',
+            abortOnFail: true
+          }, {
+            type: 'add',
+            path: './app/containers/{{properCase name}}Page.js',
+            templateFile: 'templates/container.js',
+            abortOnFail: true
+          }, {
+            type: 'add',
+            path: './app/reducers/{{camelCase name}}.js',
+            templateFile: 'templates/reducer.js',
+            abortOnFail: true
+          },
+          {
+            type: 'modify',
+            path: './app/reducers/index.js',
+            pattern: /(const rootReducer\s=\scombineReducers\(\{)/gi,
+            template: '$1\n  {{camelCase name}},'
+          },
+          {
+            type: 'modify',
+            path: './app/reducers/index.js',
+            pattern: /(import \{ routerReducer as routing } from 'react-router-redux';)/gi,
+            template: '$1\nimport {{camelCase name}} from \'./{{camelCase name}}\';'
+          }
+        ]);
+      }
+      return actions;
+    }
+
+  });
+};
+

--- a/templates/actions.js
+++ b/templates/actions.js
@@ -1,0 +1,17 @@
+// @flow
+import type { {{ camelCase name }}StateType } from '../reducers/{{ camelCase name }}';
+
+export const INCREMENT = 'INCREMENT';
+export const DECREMENT = 'DECREMENT';
+
+export function increment() {
+  return {
+    type: INCREMENT
+  };
+}
+
+export function decrement() {
+  return {
+    type: DECREMENT
+  };
+}

--- a/templates/container.js
+++ b/templates/container.js
@@ -1,0 +1,16 @@
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import {{properCase name}} from '../components/{{properCase name}}';
+import * as {{properCase name}}Actions from '../actions/{{camelCase name}}';
+
+function mapStateToProps(state) {
+  return {
+    value: state.{{camelCase name}}
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators({{properCase name}}Actions, dispatch);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)({{properCase name}});

--- a/templates/reducer.js
+++ b/templates/reducer.js
@@ -1,0 +1,21 @@
+// @flow
+import { INCREMENT, DECREMENT } from '../actions/{{camelCase name}}';
+
+export type counterStateType = {
+  value: number
+};
+
+type actionType = {
+  type: string
+};
+
+export default function counter(state: number = 0, action: actionType) {
+  switch (action.type) {
+    case INCREMENT:
+      return state + 1;
+    case DECREMENT:
+      return state - 1;
+    default:
+      return state;
+  }
+}

--- a/templates/stateful.js
+++ b/templates/stateful.js
@@ -1,0 +1,31 @@
+// @flow
+import React, { Component } from 'react';
+{{#if styled}}
+import styles from './{{ properCase name }}.css';
+{{/if}}
+
+class {{ properCase name }} extends Component {
+  props: {
+    value: number
+  };
+
+  render() {
+    const { increment, decrement, value } = this.props;
+    return (
+      <div>
+        <h4>A stateful component with a single value <p{{#if styled}}className={styles.value}{{/if}}>{value}</p></h4>
+
+        <button className={styles.btn} onClick={increment} data-tclass="btn">
+          <i className="fa fa-plus" />
+        </button>
+
+        <button className={styles.btn} onClick={decrement} data-tclass="btn">
+          <i className="fa fa-minus" />
+        </button>
+
+      </div>
+    );
+  }
+}
+
+export default {{ properCase name }};

--- a/templates/stateful.js
+++ b/templates/stateful.js
@@ -13,7 +13,7 @@ class {{ properCase name }} extends Component {
     const { increment, decrement, value } = this.props;
     return (
       <div>
-        <h4>A stateful component with a single value <p{{#if styled}}className={styles.value}{{/if}}>{value}</p></h4>
+        <h4>A stateful component with a single value <p{{#if styled}} className={styles.value}{{/if}}>{value}</p></h4>
 
         <button className={styles.btn} onClick={increment} data-tclass="btn">
           <i className="fa fa-plus" />

--- a/templates/stateless.js
+++ b/templates/stateless.js
@@ -1,0 +1,10 @@
+import React from 'react';
+{{#if styled}}
+import styles from './{{ properCase name }}.css';
+{{/if}}
+
+export const {{ properCase name }} () => (
+  <div>
+    <h3>such stateless, wow!</h3>
+  </div>
+);

--- a/templates/style.css
+++ b/templates/style.css
@@ -1,0 +1,9 @@
+{{#if stateless}}
+.someStyle {
+  color: red;
+}
+{{else}}
+.value {
+  color: red;
+}
+{{/if}}


### PR DESCRIPTION
Hello,
I've been using this boilerplate for some time now, and something that's always bothered me was the lack of CLI actions to quickly create components, especially so for stateful components as you have to create multiple files and edit some others. It was tedious.

I stumbled yesterday across `plop` and lo and behold! With this modification, you can `npm run plop` to create a new component or helper. The files are created automatically and the `reducers/index.js` is edited as well, getting you started immediately.

You can either create a helper file in the utils folder, a styled or not stateless component, or a styled or not stateful component.

All that's left is to edit the `configureStore.development.js` if a stateful component is added, but that's all I have time for today, and I'm not even sure this pull request will be accepted, so... :)

What's more, the `plopfile` can be extended indefinitely by the contributors or the users themselves.
Hope this helps.