### PR TITLE
Use local flow-bin package

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "javascript.validate.enable": false,
+  "flow.useNPMPackagedFlow": true,
   "search.exclude": {
     ".git": true,
     "node_modules": true,


### PR DESCRIPTION
If this setting is not present then flow extension suggests to install
flow globally which should is not necessary at all because locally
flow-bin is already available.