### PR TITLE
Redundant webpack `node_modules` resolve in dev.dll.js

### DIFF
--- a/webpack.config.renderer.dev.dll.js
+++ b/webpack.config.renderer.dev.dll.js
@@ -155,7 +155,6 @@ export default merge.smart(baseConfig, {
   resolve: {
     modules: [
       'app',
-      'node_modules',
     ],
   },
 


### PR DESCRIPTION
Since all webpack configs inherit the base config, and the base config contains `node_modules` in its module resolves, there's no need for this.