### PR TITLE
Revert from BrowserHistory to HashHistory

### DIFF
--- a/app/store/configureStore.development.js
+++ b/app/store/configureStore.development.js
@@ -1,13 +1,13 @@
 import { createStore, applyMiddleware, compose } from 'redux';
 import thunk from 'redux-thunk';
-import { createBrowserHistory } from 'history';
+import { createHashHistory } from 'history';
 import { routerMiddleware, routerActions } from 'react-router-redux';
 import { createLogger } from 'redux-logger';
 import rootReducer from '../reducers';
 import * as counterActions from '../actions/counter';
 import type { counterStateType } from '../reducers/counter';
 
-const history = createBrowserHistory();
+const history = createHashHistory();
 
 const configureStore = (initialState: ?counterStateType) => {
   // Redux Configuration


### PR DESCRIPTION
Partially fix #955 
Reloading <kbd>CTRL</kbd>+<kbd>R</kbd> cause the UI not to reload if not on `/` path.

