### PR TITLE
Make runTests.js exit non-zero when tests fail

### DIFF
--- a/test/runTests.js
+++ b/test/runTests.js
@@ -6,4 +6,6 @@ const pattern = process.argv[2] === 'e2e'
   ? `test${s}e2e${s}.+\\.spec\\.js`
   : `test${s}(?!e2e${s})[^${s}]+${s}.+\\.spec\\.js$`;
 
-spawn.sync(path.normalize('./node_modules/.bin/jest'), [pattern], { stdio: 'inherit' });
+const result = spawn.sync(path.normalize('./node_modules/.bin/jest'), [pattern], { stdio: 'inherit' });
+
+process.exit(result.status);


### PR DESCRIPTION
runTests.js always exits status zero, causing CI not to notice when tests fail.
