### PR TITLE
Changed webpack renderer dev node config

### DIFF
--- a/webpack.config.renderer.dev.js
+++ b/webpack.config.renderer.dev.js
@@ -236,6 +236,11 @@ export default merge.smart(baseConfig, {
     }),
   ],
 
+  node: {
+    __dirname: false,
+    __filename: false
+  },
+
   devServer: {
     port,
     publicPath,


### PR DESCRIPTION
@jhen0409 @dustintownsend @talha131 @slapbox What do you think about this? I feel like this is what suites most apps. Its also pretty confusing to have `__dirname` and `__filename` [defined differently in production](https://github.com/chentsulin/electron-react-boilerplate/blob/master/webpack.config.main.prod.js#L55-L58). Would love your thoughts on this.