### PR TITLE
Use Yarn instead of npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ And then install dependencies with yarn.
 $ cd your-project-name
 $ yarn
 ```
-**Note**: If you can't use [yarn](https://github.com/yarnpkg/yarn) for some reason, try $ npm install. 
+**Note**: If you can't use [yarn](https://github.com/yarnpkg/yarn) for some reason, try `npm install`.
 
 ## Run
 

--- a/README.md
+++ b/README.md
@@ -38,12 +38,13 @@ First, clone the repo via git:
 git clone --depth=1 https://github.com/chentsulin/electron-react-boilerplate.git your-project-name
 ```
 
-And then install dependencies.
-**ProTip**: Install with [yarn](https://github.com/yarnpkg/yarn) for faster and safer installation:
+And then install dependencies with yarn.
 
 ```bash
-$ cd your-project-name && npm install
+$ cd your-project-name
+$ yarn
 ```
+**Note**: If you can't use [yarn](https://github.com/yarnpkg/yarn) for some reason, try $ npm install. 
 
 ## Run
 


### PR DESCRIPTION
There's a problem with npm install and the option to package afterward. With yarn, you don't have this. I know it may be another required technology, but we need to change the doc if we don't fix the problem soon.

(see issue #1065)