### PR TITLE
Include `test/setup.js` before each test run.

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,8 @@
     ],
     "transform": {
       "^.+\\.js$": "babel-jest"
-    }
+    },
+    "setupTestFrameworkScriptFile": "./test/setup.js"
   },
   "devDependencies": {
     "babel-core": "^6.24.1",

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,6 +1,6 @@
-import { jsdom } from 'jsdom';
+import { JSDOM } from 'jsdom';
 
-global.document = jsdom('<!doctype html><html><body></body></html>');
+global.document = new JSDOM('<!doctype html><html><body></body></html>');
 global.window = document.defaultView;
 global.navigator = global.window.navigator;
 window.localStorage = window.sessionStorage = {

--- a/test/setup/setup.spec.js
+++ b/test/setup/setup.spec.js
@@ -1,5 +1,0 @@
-describe('setup', () => {
-  it('should mock localStorage', () => {
-    expect(typeof localStorage).toBe('object');
-  });
-});

--- a/test/setup/setup.spec.js
+++ b/test/setup/setup.spec.js
@@ -1,0 +1,5 @@
+describe('setup', () => {
+  it('should mock localStorage', () => {
+    expect(typeof localStorage).toBe('object');
+  });
+});


### PR DESCRIPTION
After migration to jest, file `test/setup.js` is no longer included before tests run, so all mocks are unavailable. This PR fix that.
Also, updated using of JSDOM and written unit test to make sure, that setup.js is included and mock of localStorage is available.