### PR TITLE
Pass arguments to jest cli

### DIFF
--- a/test/runTests.js
+++ b/test/runTests.js
@@ -6,6 +6,10 @@ const pattern = process.argv[2] === 'e2e'
   ? `test${s}e2e${s}.+\\.spec\\.js`
   : `test${s}(?!e2e${s})[^${s}]+${s}.+\\.spec\\.js$`;
 
-const result = spawn.sync(path.normalize('./node_modules/.bin/jest'), [pattern], { stdio: 'inherit' });
+const result = spawn.sync(
+  path.normalize('./node_modules/.bin/jest'),
+  [pattern, ...process.argv.slice(2)],
+  { stdio: 'inherit' }
+);
 
 process.exit(result.status);


### PR DESCRIPTION
Pass arguments to jest cli.
With that you can use it for check coverage like `npm test -- --coverage` or update snapshots like `npm test -- --u`.

Closes https://github.com/chentsulin/electron-react-boilerplate/issues/929