### PR TITLE
Fix deprecation in webpack.config.renderer.dev.js

### DIFF
--- a/webpack.config.renderer.dev.js
+++ b/webpack.config.renderer.dev.js
@@ -264,7 +264,7 @@ export default merge.smart(baseConfig, {
       verbose: true,
       disableDotRule: false,
     },
-    setup() {
+    before() {
       if (process.env.START_HOT) {
         console.log('Staring Main Process...');
         spawn(


### PR DESCRIPTION
Hello,

Thanks for your work! I had a deprecation notice when I tried to run the following command `npm run dev`

