### PR TITLE
Clarify running instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Start the app in the `dev` environment. This starts the renderer process in [**h
 $ npm run dev
 ```
 
-Alternatively, run these two commands __simultaneously__ in different console tabs:
+Alternatively, you can run the renderer and main processes separately. This way, you can restart one process without waiting for the other. Run these two commands __simultaneously__ in different console tabs:
 
 ```bash
 $ npm run start-renderer-dev

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Start the app in the `dev` environment. This starts the renderer process in [**h
 $ npm run dev
 ```
 
-Run these two commands __simultaneously__ in different console tabs:
+Alternatively, run these two commands __simultaneously__ in different console tabs:
 
 ```bash
 $ npm run start-renderer-dev

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Start the app in the `dev` environment. This starts the renderer process in [**h
 $ npm run dev
 ```
 
-Alternatively, you can run the renderer and main processes separately. This way, you can restart one process without waiting for the other. Run these two commands __simultaneously__ in different console tabs:
+Alternatively, you can run the renderer and main processes separately. This way, you can restart one process without waiting for the other. Run these two commands **simultaneously** in different console tabs:
 
 ```bash
 $ npm run start-renderer-dev


### PR DESCRIPTION
Added the word "Alternatively" to the run instructions to make it a little clearer that the second set of scripts does the same thing as the first.

Is there some reason a person would want to run those two scripts instead of just `npm run dev`?  Should I add some explanation for why they'd want to do that?