### PR TITLE
Remove jsdom dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,6 @@
     "flow-typed": "^2.3.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^22.1.4",
-    "jsdom": "^11.6.2",
     "minimist": "^1.2.0",
     "node-sass": "^4.7.2",
     "npm-logical-tree": "^1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5668,7 +5668,7 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
-jsdom@^11.5.1, jsdom@^11.6.2:
+jsdom@^11.5.1:
   version "11.6.2"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.6.2.tgz#25d1ef332d48adf77fc5221fe2619967923f16bb"
   dependencies:


### PR DESCRIPTION
[Jest](https://facebook.github.io/jest/docs/en/configuration.html#testenvironment-string) now ships with jsdom.