### PR TITLE
Remove publicPath from webpack.config.renderer.prod

### DIFF
--- a/webpack.config.renderer.prod.js
+++ b/webpack.config.renderer.prod.js
@@ -22,7 +22,6 @@ export default merge.smart(baseConfig, {
 
   output: {
     path: path.join(__dirname, 'app/dist'),
-    publicPath: './dist/',
     filename: 'renderer.prod.js'
   },
 
@@ -32,7 +31,6 @@ export default merge.smart(baseConfig, {
       {
         test: /\.global\.css$/,
         use: ExtractTextPlugin.extract({
-          publicPath: './',
           use: {
             loader: 'css-loader',
             options: {


### PR DESCRIPTION
Webpack was adding `/dist` to the beginning of every URL referenced relatively from `styles.css` or `renderer.prod.js`, causing 404 errors on assets referenced from those bundles.

This fix removes the need for `publicPath` to be forced to the proper value in the config for `ExtractTextPlugin`, thus fixing asset references for all transforms in the renderer prod bundle.

Fixes #1426 