### PR TITLE
Code example: Exhibit how Flow types don't work in production build

### DIFF
--- a/app/TestClass.js
+++ b/app/TestClass.js
@@ -1,0 +1,19 @@
+// @flow
+
+type GoogleAccount = {
+  upstreamId: string,
+}
+
+export default class TestClass {
+  static accountFlowType = GoogleAccount;
+
+  constructor() {
+    console.log(`Creating instance of TestClass`);
+
+    const account: GoogleAccount = {
+      upstreamId: 'foo',
+    };
+
+    console.log(`account`, account);
+  }
+}

--- a/app/index.js
+++ b/app/index.js
@@ -5,6 +5,10 @@ import Root from './containers/Root';
 import { configureStore, history } from './store/configureStore';
 import './app.global.css';
 
+import TestClass from './TestClass';
+
+const testObject = new TestClass();
+
 const store = configureStore();
 
 render(


### PR DESCRIPTION
⚠️ DO NOT MERGE, example code only

First off, this boilerplate is epic. Thank you for working on it and making it public.

I'm trying to use flow-runtime in my app. I notice that when I build the production package Flow types in classes I've added don't seem to work.

How I'm building the app:
```
yarn
DEBUG_PROD=true yarn package
```

What I see when I run the app:
<img width="484" alt="developer_tools_-_file____applications_electronreact_app_contents_resources_app_asar_app_html" src="https://user-images.githubusercontent.com/107841/39553692-bffdf6cc-4e23-11e8-9469-12b7732941c4.png">

I notice that in .babelrc the flow-runtime plugin is only specified for development. I tried various ways of adding flow-runtime to production, but get other errors about the transform-decorators-legacy plugin.

How can I make sure Flow types work in my own classes in the production builds?
