### PR TITLE
Allow flow definitions to be referenced in production build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,7 +7,11 @@
     "stage-0",
     "react"
   ],
-  "plugins": ["add-module-exports"],
+  "plugins": [
+    "add-module-exports",
+    "flow-runtime",
+    "transform-decorators-legacy"
+  ],
   "env": {
     "production": {
       "presets": ["react-optimize"],
@@ -16,11 +20,7 @@
     "development": {
       "plugins": [
         "transform-class-properties",
-        "transform-es2015-classes",
-        ["flow-runtime", {
-          "assert": true,
-          "annotate": true
-        }]
+        "transform-es2015-classes"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -187,6 +187,7 @@
     "webpack-merge": "^4.1.1"
   },
   "dependencies": {
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "devtron": "^1.4.0",
     "electron-debug": "^1.5.0",
     "font-awesome": "^4.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -783,7 +783,7 @@ babel-plugin-syntax-class-properties@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
 
-babel-plugin-syntax-decorators@^6.13.0:
+babel-plugin-syntax-decorators@^6.1.18, babel-plugin-syntax-decorators@^6.13.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz#312563b4dbde3cc806cee3e416cceeaddd11ac0b"
 
@@ -855,6 +855,14 @@ babel-plugin-transform-class-properties@^6.24.1, babel-plugin-transform-class-pr
     babel-plugin-syntax-class-properties "^6.8.0"
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
+
+babel-plugin-transform-decorators-legacy@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-decorators-legacy/-/babel-plugin-transform-decorators-legacy-1.3.4.tgz#741b58f6c5bce9e6027e0882d9c994f04f366925"
+  dependencies:
+    babel-plugin-syntax-decorators "^6.1.18"
+    babel-runtime "^6.2.0"
+    babel-template "^6.3.0"
 
 babel-plugin-transform-decorators@^6.24.1:
   version "6.24.1"
@@ -1317,14 +1325,14 @@ babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
+babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
 
-babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0:
+babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0, babel-template@^6.3.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
   dependencies:


### PR DESCRIPTION
In certain cases, we may want code running in production to be able to
access Flow type definitions. By default, flow-runtime allows that,
and for performance reasons flow-runtime only runs assertions when
`process.env.NODE_ENV === 'development'`.

This change makes Flow types accessible to code, but assertions just
aren't run. This makes Flow types useable in dynamic interesting
ways. For example, a class could define a property that points to its
Flow type so other code using the class can do additional type
checking given a dynamic Flow type.

Options and default values for babel-plugin-flow-runtime:
- https://codemix.github.io/flow-runtime/#/babel-plugin-flow-runtime
- Note: Assertions only run in dev, no need to re-specify in .babelrc

From: https://codemix.github.io/flow-runtime/#/
>  It does incur a performance hit though, so it's often sensible to
turn off
> assertion mode in production, leaving type declarations intact but
eliminating
> the associated overhead.

NOTE: The updates to yarn.lock are necessary because we need to install `babel-plugin-transform-decorators-legacy` in the non-development area of the app (it's a runtime dependency).

Working example: https://github.com/chentsulin/electron-react-boilerplate/compare/master...aguynamedben:flow-definitions-in-prod-working?expand=1

GitHub Issue: https://github.com/chentsulin/electron-react-boilerplate/issues/1535