### PR TITLE
Upgrade Electron to 1.7.15, fix critical security flaw

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "cross-spawn": "^6.0.4",
     "css-loader": "^0.28.9",
     "detect-port": "^1.2.2",
-    "electron": "^1.7.11",
+    "electron": "1.7.15",
     "electron-builder": "^19.55.3",
     "electron-devtools-installer": "^2.2.3",
     "electron-rebuild": "^1.7.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3156,9 +3156,9 @@ electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.30:
   version "1.3.31"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.31.tgz#00d832cba9fe2358652b0c48a8816c8e3a037e9f"
 
-electron@^1.7.11:
-  version "1.7.12"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.7.12.tgz#dcc61a2c1b0c3df25f68b3425379a01abd01190e"
+electron@1.7.15:
+  version "1.7.15"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.7.15.tgz#1234fa3645b6c09017815515833a86c26989ef49"
   dependencies:
     "@types/node" "^7.0.18"
     electron-download "^3.0.1"


### PR DESCRIPTION
Fixes CVE-2018-1000136.
https://www.trustwave.com/Resources/SpiderLabs-Blog/CVE-2018-1000136---Electron-nodeIntegration-Bypass/

Reported in https://github.com/chentsulin/electron-react-boilerplate/issues/1547