### PR TITLE
Move UglifyJSPlugin

### DIFF
--- a/webpack.config.main.prod.js
+++ b/webpack.config.main.prod.js
@@ -25,12 +25,16 @@ export default merge.smart(baseConfig, {
     filename: './app/main.prod.js'
   },
 
-  plugins: [
-    new UglifyJSPlugin({
-      parallel: true,
-      sourceMap: true
-    }),
+  optimization: {
+    minimizer: [
+      new UglifyJSPlugin({
+        parallel: true,
+        sourceMap: true
+      })
+    ]
+  },
 
+  plugins: [
     new BundleAnalyzerPlugin({
       analyzerMode:
         process.env.OPEN_ANALYZER === 'true' ? 'server' : 'disabled',

--- a/webpack.config.renderer.prod.js
+++ b/webpack.config.renderer.prod.js
@@ -156,7 +156,13 @@ export default merge.smart(baseConfig, {
   },
 
   optimization: {
-    minimizer: [new OptimizeCSSAssetsPlugin()]
+    minimizer: [
+      new UglifyJSPlugin({
+        parallel: true,
+        sourceMap: true
+      }),
+      new OptimizeCSSAssetsPlugin()
+    ]
   },
 
   plugins: [
@@ -171,11 +177,6 @@ export default merge.smart(baseConfig, {
      */
     new webpack.EnvironmentPlugin({
       NODE_ENV: 'production'
-    }),
-
-    new UglifyJSPlugin({
-      parallel: true,
-      sourceMap: true
     }),
 
     new MiniCssExtractPlugin({


### PR DESCRIPTION
`mode: 'production'` is specified in `webpack.config.main.prod.js` and `webpack.config.renderer.prod.js`. That enables `UglifyJSPlugin`. See [default optimization options](https://webpack.js.org/concepts/mode/). Specifying a custom `UglifyJSPlugin` instance in `optimization.minimizer` will [override the default minimizer](https://webpack.js.org/configuration/optimization/#optimization-minimizer).