### PR TITLE
error reporting (WIP)

### DIFF
--- a/app/actions/errorReporting.js
+++ b/app/actions/errorReporting.js
@@ -1,0 +1,8 @@
+// @flow
+export const TOGGLE_ERROR_REPORTING = 'TOGGLE_ERROR_REPORTING';
+
+export function toggleErrorReporting() {
+  return {
+    type: TOGGLE_ERROR_REPORTING
+  };
+}

--- a/app/components/ErrorReporting.js
+++ b/app/components/ErrorReporting.js
@@ -1,0 +1,94 @@
+// @flow
+import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
+
+import ErrorHandler from '../errorHandling/RendererProcessErrorHandler';
+
+// TODO move to error handler middleware
+const errorHandler = new ErrorHandler();
+errorHandler.init();
+
+type Props = {
+  toggleErrorReporting: () => void,
+  isReportingErrors: boolean
+};
+
+export default class ErrorReporting extends Component<Props> {
+  props: Props;
+  simulateRendererError = () => {
+    throw new Error('simulated error');
+  };
+  simulateRendererCrash = () => {
+    const shouldContinue = global.confirm(
+      'This will CRASH the app, and will require a restart. use it to test whether electron crash reporter is working propertly'
+    );
+    if (shouldContinue) {
+      // $FlowFixMe
+      process.crash();
+    }
+  };
+  simulateMainProcessError = () => {
+    errorHandler.sendDangerousTestErrorToMain();
+  };
+  simulateMainProcessCrash = () => {
+    const shouldContinue = global.confirm(
+      'This will CRASH the app, and will require a restart. use it to test whether electron crash reporter is working propertly'
+    );
+    if (shouldContinue) {
+      // $FlowFixMe
+      errorHandler.sendDangerousTestCrashToMain();
+    }
+  };
+
+  toggleErrorReporting = () => {
+    this.props.toggleErrorReporting();
+    // TODO move to error handler middleware
+    if (this.props.isReportingErrors) {
+      errorHandler.stopReporting();
+    } else {
+      errorHandler.startReporting();
+    }
+  };
+  render() {
+    const { isReportingErrors } = this.props;
+    return (
+      <div>
+        <Link to="/">Back home</Link>
+        <h1>Error Reporting Demo</h1>
+        <p>Make sure your console is open!</p>
+        <p>
+          To test crash reporting, run `$ node app/test-crash-server.js` to
+          start a dummy server that logs crash reports
+        </p>
+        <p>Currenty reporting errors: {String(isReportingErrors)}</p>
+        <div>
+          <button onClick={this.toggleErrorReporting}>
+            Toggle error reporting
+          </button>
+        </div>
+        <h6>Simulate Renderer errors</h6>
+        <div>
+          <button onClick={this.simulateRendererError}>
+            Simulate renderer error
+          </button>
+        </div>
+        <div>
+          <button onClick={this.simulateRendererCrash}>
+            Simulate renderer crash
+          </button>
+        </div>
+        <h6>Simulate main process errors</h6>
+        <div>
+          <button onClick={this.simulateMainProcessError}>
+            Simulate main process error
+          </button>
+        </div>
+        <div>
+          <button onClick={this.simulateMainProcessCrash}>
+            Simulate main process crash
+          </button>
+        </div>
+      </div>
+    );
+  }
+}

--- a/app/components/Home.js
+++ b/app/components/Home.js
@@ -13,7 +13,12 @@ export default class Home extends Component<Props> {
       <div>
         <div className={styles.container} data-tid="container">
           <h2>Home</h2>
-          <Link to="/counter">to Counter</Link>
+          <div>
+            <Link to="/counter">to Counter</Link>
+          </div>
+          <div>
+            <Link to="/error-reporting">to Error reporting</Link>
+          </div>
         </div>
       </div>
     );

--- a/app/containers/ErrorReportingPage.js
+++ b/app/containers/ErrorReportingPage.js
@@ -1,0 +1,16 @@
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import ErrorReporting from '../components/ErrorReporting';
+import * as ErrorReportingActions from '../actions/errorReporting';
+
+function mapStateToProps(state) {
+  return {
+    isReportingErrors: state.errorReporting
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators(ErrorReportingActions, dispatch);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ErrorReporting);

--- a/app/errorHandling/MainProcessErrorHandler.js
+++ b/app/errorHandling/MainProcessErrorHandler.js
@@ -1,0 +1,109 @@
+import { crashReporter, ipcMain, dialog } from 'electron';
+
+import {
+  getCrashReporterOptions,
+  IPC_SET_ERROR_REPORTING,
+  IPC_DANGER_THROW_ERROR_NOT_FOR_PRODUCTION,
+  IPC_DANGER_CRASH_NOT_FOR_PRODUCTION
+} from './errorHandlerConfig';
+
+// replace with your error reporting tool/service
+// eslint-disable-next-line no-unused-vars
+const errorReportingService = error => {
+  console.log('error has been reported!');
+};
+
+class mainProcessErrorHandler {
+  isReporting = false;
+  handleUncaughtExceptions = true;
+  constructor(opts) {
+    this.validateConstructorOpts(opts);
+    const { webContents } = opts;
+    this.webContents = webContents;
+  }
+  init() {
+    ipcMain.on(IPC_SET_ERROR_REPORTING, this.onIpcSetErrorReporting);
+    if (this.handleUncaughtExceptions) {
+      process.on('uncaughtException', this.onUncaughtException);
+    }
+    // recommended: check if isReporting is set to true in local db
+    // call this.startReporting()
+
+    // REMOVE FOR PRODUCTION
+    if (process.env.NODE_ENV === 'development') {
+      ipcMain.on(
+        IPC_DANGER_THROW_ERROR_NOT_FOR_PRODUCTION,
+        this.onDangerousTestErrorFromRenderer
+      );
+      ipcMain.on(
+        IPC_DANGER_CRASH_NOT_FOR_PRODUCTION,
+        this.onDangerousCrashFromRenderer
+      );
+    }
+  }
+  startReporting() {
+    if (this.isReporting) {
+      console.warn('error reporting is already on');
+      return;
+    }
+    console.log('starting to report errors');
+    crashReporter.start({
+      ...getCrashReporterOptions('main'),
+      uploadToServer: true
+    });
+    this.isReporting = true;
+    // recommended: save isReporting new value to local db
+  }
+  stopReporting() {
+    if (!this.isReporting) {
+      console.warn('error reporting is already off');
+      return;
+    }
+    console.log('stopping to report errors');
+    crashReporter.start({
+      ...getCrashReporterOptions('main'),
+      uploadToServer: false
+    });
+    this.isReporting = false;
+    // recommended: save isReporting new value to local db
+  }
+  onUncaughtException = error => {
+    this.report(error);
+    // TODO :: compare to electron native uncaught error
+    dialog.showErrorBox(
+      `${error.message} (We suggest you restart the app)`,
+      error.stack
+    );
+  };
+  report(error) {
+    console.error('error in main process', error);
+    if (!this.isReporting) {
+      return;
+    }
+    // replace with your error reporting tool/service
+    errorReportingService(error);
+  }
+  onIpcSetErrorReporting = (evt, nextIsReporting) => {
+    if (nextIsReporting) {
+      this.startReporting();
+    } else {
+      this.stopReporting();
+    }
+  };
+  // eslint-disable-next-line class-methods-use-this
+  validateConstructorOpts(opts) {
+    if (!opts.webContents) {
+      throw new Error('pass win.webContents to constructor');
+    }
+  }
+  // REMOVE FOR PRODUCTION
+  onDangerousTestErrorFromRenderer = () => {
+    throw new Error('test error from renderer');
+  };
+  // REMOVE FOR PRODUCTION
+  onDangerousCrashFromRenderer = () => {
+    process.crash();
+  };
+}
+
+export default mainProcessErrorHandler;

--- a/app/errorHandling/RendererProcessErrorHandler.js
+++ b/app/errorHandling/RendererProcessErrorHandler.js
@@ -1,0 +1,82 @@
+import { crashReporter, ipcRenderer } from 'electron';
+
+import {
+  getCrashReporterOptions,
+  IPC_SET_ERROR_REPORTING,
+  IPC_DANGER_THROW_ERROR_NOT_FOR_PRODUCTION,
+  IPC_DANGER_CRASH_NOT_FOR_PRODUCTION
+} from './errorHandlerConfig';
+
+// replace with your error reporting tool/service
+const errorReportingService = error => {
+  // eslint-disable-line no-unused-vars
+  console.log('error has been reported!');
+};
+
+class mainProcessErrorHandler {
+  isReporting = false;
+
+  init() {
+    window.addEventListener('error', this.onUncaughtWindowError);
+    // recommended: check if isReporting is set to true in local db
+    // call this.startReporting()
+  }
+  startReporting() {
+    if (this.isReporting) {
+      console.warn('error reporting is already on');
+      return;
+    }
+    console.log('starting to report errors');
+    ipcRenderer.send(IPC_SET_ERROR_REPORTING, true);
+    crashReporter.start({
+      ...getCrashReporterOptions('renderer'),
+      uploadToServer: true
+    });
+    this.isReporting = true;
+    // recommended: save isReporting new value to local db
+  }
+  stopReporting() {
+    if (!this.isReporting) {
+      console.warn('error reporting is already off');
+      return;
+    }
+    ipcRenderer.send(IPC_SET_ERROR_REPORTING, false);
+    console.log('stopping to report errors');
+    crashReporter.start({
+      ...getCrashReporterOptions('renderer'),
+      uploadToServer: false
+    });
+    this.isReporting = false;
+    // recommended: save isReporting new value to local db
+  }
+  onUncaughtWindowError = (errorEvent: ErrorEvent) => {
+    // stop window from logging error to console
+    errorEvent.preventDefault();
+    // since we handle it ourselves here
+    this.report(errorEvent.error);
+  };
+  report(error) {
+    console.error('error in renderer process', error);
+    if (!this.isReporting) {
+      return;
+    }
+    // replace with your error reporting tool/service
+    errorReportingService(error);
+  }
+  // REMOVE FOR PRODUCTION
+  // eslint-disable-next-line class-methods-use-this
+  sendDangerousTestErrorToMain() {
+    if (process.env.NODE_ENV === 'development') {
+      ipcRenderer.send(IPC_DANGER_THROW_ERROR_NOT_FOR_PRODUCTION, true);
+    }
+  }
+  // REMOVE FOR PRODUCTION
+  // eslint-disable-next-line class-methods-use-this
+  sendDangerousTestCrashToMain() {
+    if (process.env.NODE_ENV === 'development') {
+      ipcRenderer.send(IPC_DANGER_CRASH_NOT_FOR_PRODUCTION, true);
+    }
+  }
+}
+
+export default mainProcessErrorHandler;

--- a/app/errorHandling/errorHandlerConfig.js
+++ b/app/errorHandling/errorHandlerConfig.js
@@ -1,0 +1,20 @@
+// @flow
+import pjson from '../../package.json';
+
+export const extraAttributes = {
+  NODE_ENV: process.env.NODE_ENV,
+  appVersion: pjson.version
+};
+
+export const getCrashReporterOptions = (processType: 'renderer' | 'main') => ({
+  productName: 'YourName',
+  companyName: 'YourCompany',
+  submitURL: 'http://localhost:4000/',
+  extra: { ...extraAttributes, processType }
+});
+
+export const IPC_SET_ERROR_REPORTING = 'ipcSetErrorReporting';
+export const IPC_DANGER_THROW_ERROR_NOT_FOR_PRODUCTION =
+  'ipcDangerThrowErrorNotForProduction';
+export const IPC_DANGER_CRASH_NOT_FOR_PRODUCTION =
+  'ipcDangerCrashNotForProduction';

--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -11,6 +11,7 @@
  * @flow
  */
 import { app, BrowserWindow } from 'electron';
+import ErrorHandlerMainProcess from './errorHandling/MainProcessErrorHandler';
 import MenuBuilder from './menu';
 
 let mainWindow = null;
@@ -65,6 +66,10 @@ app.on('ready', async () => {
     width: 1024,
     height: 728
   });
+  const errorHandler = new ErrorHandlerMainProcess({
+    webContents: mainWindow.webContents
+  });
+  errorHandler.init();
 
   mainWindow.loadURL(`file://${__dirname}/app.html`);
 

--- a/app/reducers/errorReporting.js
+++ b/app/reducers/errorReporting.js
@@ -1,0 +1,22 @@
+// @flow
+import { TOGGLE_ERROR_REPORTING } from '../actions/errorReporting';
+
+export type errorReportingStateType = {
+  +isReportingErrors: boolean
+};
+
+type actionType = {
+  +type: string
+};
+
+export default function errorReporting(
+  state: boolean = false,
+  action: actionType
+) {
+  switch (action.type) {
+    case TOGGLE_ERROR_REPORTING:
+      return !state;
+    default:
+      return state;
+  }
+}

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -2,9 +2,11 @@
 import { combineReducers } from 'redux';
 import { routerReducer as router } from 'react-router-redux';
 import counter from './counter';
+import errorReporting from './errorReporting';
 
 const rootReducer = combineReducers({
   counter,
+  errorReporting,
   router
 });
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -4,11 +4,13 @@ import { Switch, Route } from 'react-router';
 import App from './containers/App';
 import HomePage from './containers/HomePage';
 import CounterPage from './containers/CounterPage';
+import ErrorReportingPage from './containers/ErrorReportingPage';
 
 export default () => (
   <App>
     <Switch>
       <Route path="/counter" component={CounterPage} />
+      <Route path="/error-reporting" component={ErrorReportingPage} />
       <Route path="/" component={HomePage} />
     </Switch>
   </App>

--- a/app/test-crash-server.js
+++ b/app/test-crash-server.js
@@ -1,0 +1,20 @@
+const http = require('http');
+
+const port = 4000;
+
+const requestHandler = (request, response) => {
+  console.log('incoming request');
+  console.log(request.url);
+  console.log(request);
+  response.end('Hello Node.js Server!');
+};
+
+const server = http.createServer(requestHandler);
+
+server.listen(port, err => {
+  if (err) {
+    return console.log('something bad happened', err);
+  }
+
+  console.log(`server is listening on ${port}`);
+});


### PR DESCRIPTION
This is a rough POC for #1593. Just wanted to get quick feedback on the direction, before we "polish" it.

let me know any thoughts you might have, corrections, Qs, etc.

Currently supports:
- Toggling electron crashReporter and error reporting on the fly on the fly from renderer process (allow user to opt in and out of error reporting)
- catch window (renderer) uncaught errors
- catch main process uncaught errors, notify user and suggest restart

Todo / ideas
- Move error reporting logic to middleware
- make better UI for error reporting testing page
- add tests
- add documentation / examples for common error and crash reporting services
- if error is caught and user is not opted in to report errors, display a modal asking for starting to report errors