### PR TITLE
refactor routes to use constants

### DIFF
--- a/app/Routes.js
+++ b/app/Routes.js
@@ -1,7 +1,7 @@
 /* eslint flowtype-errors/show-errors: 0 */
 import React from 'react';
 import { Switch, Route } from 'react-router';
-import * as routes from './constants/routes';
+import routes from './constants/routes.json';
 import App from './containers/App';
 import HomePage from './containers/HomePage';
 import CounterPage from './containers/CounterPage';

--- a/app/Routes.js
+++ b/app/Routes.js
@@ -1,6 +1,7 @@
 /* eslint flowtype-errors/show-errors: 0 */
 import React from 'react';
 import { Switch, Route } from 'react-router';
+import * as routes from './constants/routes';
 import App from './containers/App';
 import HomePage from './containers/HomePage';
 import CounterPage from './containers/CounterPage';
@@ -8,8 +9,8 @@ import CounterPage from './containers/CounterPage';
 export default () => (
   <App>
     <Switch>
-      <Route path="/counter" component={CounterPage} />
-      <Route path="/" component={HomePage} />
+      <Route path={routes.COUNTER} component={CounterPage} />
+      <Route path={routes.HOME} component={HomePage} />
     </Switch>
   </App>
 );

--- a/app/components/Counter.js
+++ b/app/components/Counter.js
@@ -2,7 +2,7 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import styles from './Counter.css';
-import * as routes from '../constants/routes';
+import routes from '../constants/routes.json';
 
 type Props = {
   increment: () => void,

--- a/app/components/Counter.js
+++ b/app/components/Counter.js
@@ -2,6 +2,7 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import styles from './Counter.css';
+import * as routes from '../constants/routes';
 
 type Props = {
   increment: () => void,
@@ -25,7 +26,7 @@ export default class Counter extends Component<Props> {
     return (
       <div>
         <div className={styles.backButton} data-tid="backButton">
-          <Link to="/">
+          <Link to={routes.HOME}>
             <i className="fa fa-arrow-left fa-3x" />
           </Link>
         </div>

--- a/app/components/Home.js
+++ b/app/components/Home.js
@@ -1,6 +1,7 @@
 // @flow
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
+import * as routes from '../constants/routes';
 import styles from './Home.css';
 
 type Props = {};
@@ -13,7 +14,7 @@ export default class Home extends Component<Props> {
       <div>
         <div className={styles.container} data-tid="container">
           <h2>Home</h2>
-          <Link to="/counter">to Counter</Link>
+          <Link to={routes.COUNTER}>to Counter</Link>
         </div>
       </div>
     );

--- a/app/components/Home.js
+++ b/app/components/Home.js
@@ -1,7 +1,7 @@
 // @flow
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
-import * as routes from '../constants/routes';
+import routes from '../constants/routes.json';
 import styles from './Home.css';
 
 type Props = {};

--- a/app/constants/routes.js
+++ b/app/constants/routes.js
@@ -1,0 +1,2 @@
+export const HOME = '/';
+export const COUNTER = '/counter';

--- a/app/constants/routes.js
+++ b/app/constants/routes.js
@@ -1,2 +1,0 @@
-export const HOME = '/';
-export const COUNTER = '/counter';

--- a/app/constants/routes.json
+++ b/app/constants/routes.json
@@ -1,0 +1,4 @@
+{
+  "HOME": "/",
+  "COUNTER": "/counter"
+}

--- a/app/containers/Root.js
+++ b/app/containers/Root.js
@@ -2,7 +2,7 @@
 import React, { Component } from 'react';
 import { Provider } from 'react-redux';
 import { ConnectedRouter } from 'react-router-redux';
-import Routes from '../routes';
+import Routes from '../Routes';
 
 type Props = {
   store: {},


### PR DESCRIPTION
- rename `routes.js` to `Routes.js` (since it exposes a `React.Component`)
- export const routes from `constants/routes.js`
- use const routes instead of hard coded through the app

resolves #1618 

