### PR TITLE
fixed the outdated redux dev tools documents url

### DIFF
--- a/app/store/configureStore.dev.js
+++ b/app/store/configureStore.dev.js
@@ -41,7 +41,7 @@ const configureStore = (initialState?: counterStateType) => {
   /* eslint-disable no-underscore-dangle */
   const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
     ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
-        // Options: http://zalmoxisus.github.io/redux-devtools-extension/API/Arguments.html
+        // Options: http://extension.remotedev.io/docs/API/Arguments.html
         actionCreators
       })
     : compose;


### PR DESCRIPTION
- fixed the outdated redux dev tools documents url
    + it moved to http://extension.remotedev.io/docs/API/Arguments.html 