### PR TITLE
Update webpack.config.renderer.prod.js

### DIFF
--- a/webpack.config.renderer.prod.js
+++ b/webpack.config.renderer.prod.js
@@ -24,7 +24,7 @@ export default merge.smart(baseConfig, {
 
   output: {
     path: path.join(__dirname, 'app/dist'),
-    publicPath: './dist/',
+    publicPath: '../dist/',
     filename: 'renderer.prod.js'
   },
 


### PR DESCRIPTION
I think this would fix a bug, which makes production's style.css's url wrong. Found this when using typeface-roboto. No matter where I import 'typeface-roboto', style.css will always be "url(./dist/xxx.woff)",but instead, it should be "url(../dist/xxx.woff)"