### PR TITLE
Added stylelint-config-prettier

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,3 +1,3 @@
 {
-  "extends": "stylelint-config-standard"
+  "extends": ["stylelint-config-standard", "stylelint-config-prettier"]
 }

--- a/package.json
+++ b/package.json
@@ -209,6 +209,7 @@
     "spectron": "^3.8.0",
     "style-loader": "^0.21.0",
     "stylelint": "^9.4.0",
+    "stylelint-config-prettier": "^4.0.0",
     "stylelint-config-standard": "^18.2.0",
     "uglifyjs-webpack-plugin": "1.2.7",
     "url-loader": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9560,6 +9560,10 @@ stylehacks@^4.0.0:
     postcss "^6.0.0"
     postcss-selector-parser "^3.0.0"
 
+stylelint-config-prettier@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-prettier/-/stylelint-config-prettier-4.0.0.tgz#8c712977be13bd25191ab8b986b5c07a3342a5dc"
+
 stylelint-config-recommended@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-2.1.0.tgz#f526d5c771c6811186d9eaedbed02195fee30858"


### PR DESCRIPTION
stylelint-config-prettier will override clashing rules with any other stylelint configs, to prevent stylelint errors being created due to prettier formatting.