### PR TITLE
VSCode Syntax Highlighting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,15 @@
 {
   "files.associations": {
-    ".eslintrc": "jsonc",
     ".babelrc": "jsonc",
-    ".prettierrc": "jsonc"
+    ".eslintrc": "jsonc",
+    ".prettierrc": "jsonc",
+
+    ".eslintcache": "json",
+    ".stylelintrc": "json",
+
+    ".dockerignore": "ignore",
+    ".eslintignore": "ignore",
+    ".flowconfig": "ignore"
   },
 
   "javascript.validate.enable": false,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,6 @@
     ".eslintrc": "jsonc",
     ".prettierrc": "jsonc",
 
-    ".eslintcache": "json",
     ".stylelintrc": "json",
 
     ".dockerignore": "ignore",


### PR DESCRIPTION
- Recognize `.eslintignore` `.dockerignore` `.flowconfig` as `ignore` filetypes (since using \# will work as a comment for all of them)

- Recognize `.eslintcache` and `.stylelintrc` as `json` filetypes. (`stylelint` will crash if `.stylelintrc` is a `json` with comments)