### PR TITLE
Fix flow errors caused by "store" prop in Root.js

### DIFF
--- a/app/actions/counter.js
+++ b/app/actions/counter.js
@@ -1,9 +1,5 @@
 // @flow
-import type { counterStateType } from '../reducers/types';
-
-type actionType = {
-  +type: string
-};
+import type { GetState, Dispatch } from '../reducers/types';
 
 export const INCREMENT_COUNTER = 'INCREMENT_COUNTER';
 export const DECREMENT_COUNTER = 'DECREMENT_COUNTER';
@@ -21,10 +17,7 @@ export function decrement() {
 }
 
 export function incrementIfOdd() {
-  return (
-    dispatch: (action: actionType) => void,
-    getState: () => counterStateType
-  ) => {
+  return (dispatch: Dispatch, getState: GetState) => {
     const { counter } = getState();
 
     if (counter % 2 === 0) {
@@ -36,7 +29,7 @@ export function incrementIfOdd() {
 }
 
 export function incrementAsync(delay: number = 1000) {
-  return (dispatch: (action: actionType) => void) => {
+  return (dispatch: Dispatch) => {
     setTimeout(() => {
       dispatch(increment());
     }, delay);

--- a/app/containers/Root.js
+++ b/app/containers/Root.js
@@ -2,10 +2,11 @@
 import React, { Component } from 'react';
 import { Provider } from 'react-redux';
 import { ConnectedRouter } from 'react-router-redux';
+import type { Store } from '../reducers/types';
 import Routes from '../Routes';
 
 type Props = {
-  store: {},
+  store: Store,
   history: {}
 };
 

--- a/app/reducers/counter.js
+++ b/app/reducers/counter.js
@@ -1,11 +1,8 @@
 // @flow
 import { INCREMENT_COUNTER, DECREMENT_COUNTER } from '../actions/counter';
+import type { Action } from './types';
 
-type actionType = {
-  +type: string
-};
-
-export default function counter(state: number = 0, action: actionType) {
+export default function counter(state: number = 0, action: Action) {
   switch (action.type) {
     case INCREMENT_COUNTER:
       return state + 1;

--- a/app/reducers/types.js
+++ b/app/reducers/types.js
@@ -1,3 +1,15 @@
+import type { Dispatch as ReduxDispatch, Store as ReduxStore } from 'redux';
+
 export type counterStateType = {
   +counter: number
 };
+
+export type Action = {
+  +type: string
+};
+
+export type GetState = () => counterStateType;
+
+export type Dispatch = ReduxDispatch<Action>;
+
+export type Store = ReduxStore<GetState, Action>;


### PR DESCRIPTION
This fixes the errors being raised by `yarn flow`. Error seems to have been introduced when upgrading `flow-bin` in #1664.

I've never used redux before so I may not have defined all the types correctly (possibly got type for state wrong). Please double-check and make any changes as needed.