### PR TITLE
Fix issues created by adding connected-react-router

### DIFF
--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -4,5 +4,9 @@ import { connectRouter } from 'connected-react-router';
 import counter from './counter';
 
 export default function createRootReducer(history: {}) {
-  return connectRouter(history)(combineReducers({ counter }));
+  const routerReducer = connectRouter(history)(() => {});
+
+  return connectRouter(history)(
+    combineReducers({ router: routerReducer, counter })
+  );
 }

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -1,11 +1,8 @@
 // @flow
 import { combineReducers } from 'redux';
-import { routerReducer as router } from 'react-router-redux';
+import { connectRouter } from 'connected-react-router';
 import counter from './counter';
 
-const rootReducer = combineReducers({
-  counter,
-  router
-});
-
-export default rootReducer;
+export default function createRootReducer(history: {}) {
+  return connectRouter(history)(combineReducers({ counter }));
+}

--- a/app/store/configureStore.dev.js
+++ b/app/store/configureStore.dev.js
@@ -1,13 +1,15 @@
 import { createStore, applyMiddleware, compose } from 'redux';
 import thunk from 'redux-thunk';
 import { createHashHistory } from 'history';
-import { routerMiddleware, routerActions } from 'react-router-redux';
+import { routerMiddleware, routerActions } from 'connected-react-router';
 import { createLogger } from 'redux-logger';
-import rootReducer from '../reducers';
+import createRootReducer from '../reducers';
 import * as counterActions from '../actions/counter';
 import type { counterStateType } from '../reducers/types';
 
 const history = createHashHistory();
+
+const rootReducer = createRootReducer(history);
 
 const configureStore = (initialState?: counterStateType) => {
   // Redux Configuration

--- a/app/store/configureStore.prod.js
+++ b/app/store/configureStore.prod.js
@@ -2,11 +2,12 @@
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 import { createHashHistory } from 'history';
-import { routerMiddleware } from 'react-router-redux';
-import rootReducer from '../reducers';
+import { routerMiddleware } from 'connected-react-router';
+import createRootReducer from '../reducers';
 import type { counterStateType } from '../reducers/types';
 
 const history = createHashHistory();
+const rootReducer = createRootReducer(history);
 const router = routerMiddleware(history);
 const enhancer = applyMiddleware(thunk, router);
 

--- a/test/containers/CounterPage.spec.js
+++ b/test/containers/CounterPage.spec.js
@@ -3,7 +3,7 @@ import Enzyme, { mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import { Provider } from 'react-redux';
 import { createBrowserHistory } from 'history';
-import { ConnectedRouter } from 'react-router-redux';
+import { ConnectedRouter } from 'connected-react-router';
 import CounterPage from '../../app/containers/CounterPage';
 import { configureStore } from '../../app/store/configureStore';
 


### PR DESCRIPTION
`react-router-redux` was still being used in some areas, switched that for `connected-react-router`.

`routerReducer` is not currently exposed by `connected-react-router`, so I followed a "hack" mentioned [here](https://github.com/supasate/connected-react-router/issues/79#issuecomment-403271755) to add that back.