### PR TITLE
WIP: Use node-modules-path module to get path to node_modules

### DIFF
--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -11,6 +11,7 @@
  * @flow
  */
 import { app, BrowserWindow } from 'electron';
+import getModulesPath from 'node-modules-path';
 import MenuBuilder from './menu';
 
 let mainWindow = null;
@@ -26,7 +27,7 @@ if (
 ) {
   require('electron-debug')();
   const path = require('path');
-  const p = path.join(__dirname, '..', 'app', 'node_modules');
+  const p = getModulesPath(path.join(__dirname, '..', 'app'));
   require('module').globalPaths.push(p);
 }
 

--- a/configs/webpack.config.base.js
+++ b/configs/webpack.config.base.js
@@ -5,23 +5,25 @@
 import path from 'path';
 import webpack from 'webpack';
 import fs from 'fs';
+import getModulesPath from 'node-modules-path';
 import { dependencies as externals } from '../app/package';
 import { dependencies as possibleExternals } from '../package';
 
 // Find all the dependencies without a `main` property and add them as webpack externals
 function filterDepWithoutEntryPoints(dep: string): boolean {
+  const depModulePath = path.join(
+    getModulesPath(path.join(__dirname, '..')),
+    `./${dep}/`
+  );
+
   // Return true if we want to add a dependency to externals
   try {
     // If the root of the dependency has an index.js, return true
-    if (
-      fs.existsSync(path.join(__dirname, '..', `node_modules/${dep}/index.js`))
-    ) {
+    if (fs.existsSync(path.join(depModulePath, './index.js'))) {
       return false;
     }
     const pgkString = fs
-      .readFileSync(
-        path.join(__dirname, '..', `node_modules/${dep}/package.json`)
-      )
+      .readFileSync(path.join(depModulePath, './package.json'))
       .toString();
     const pkg = JSON.parse(pgkString);
     const fields = ['main', 'module', 'jsnext:main', 'browser'];
@@ -64,7 +66,7 @@ export default {
    */
   resolve: {
     extensions: ['.js', '.jsx', '.json'],
-    modules: [path.join(__dirname, '..', 'app'), 'node_modules']
+    modules: [path.join(__dirname, '..', 'app'), getModulesPath(__dirname)]
   },
 
   plugins: [

--- a/internals/scripts/CheckNativeDep.js
+++ b/internals/scripts/CheckNativeDep.js
@@ -1,16 +1,22 @@
 // @flow
 import fs from 'fs';
 import chalk from 'chalk';
+import getModulesPath from 'node-modules-path';
+import path from 'path';
 import { execSync } from 'child_process';
 import { dependencies } from '../../package';
+
+const modulesPath = getModulesPath(__dirname);
 
 (() => {
   if (!dependencies) return;
 
   const dependenciesKeys = Object.keys(dependencies);
   const nativeDeps = fs
-    .readdirSync('node_modules')
-    .filter(folder => fs.existsSync(`node_modules/${folder}/binding.gyp`));
+    .readdirSync(modulesPath)
+    .filter(folder =>
+      fs.existsSync(path.join(modulesPath, `./${folder}/binding.gyp`))
+    );
 
   try {
     // Find the reason for why the dependency is installed. If it is installed

--- a/internals/scripts/ElectronRebuild.js
+++ b/internals/scripts/ElectronRebuild.js
@@ -2,16 +2,19 @@
 import path from 'path';
 import { execSync } from 'child_process';
 import fs from 'fs';
+import getModulesPath from 'node-modules-path';
 import { dependencies } from '../../app/package';
 
-const nodeModulesPath = path.join(__dirname, '..', '..', 'app', 'node_modules');
+const nodeModulesPath = getModulesPath(path.join(__dirname, '..', '..', 'app'));
 
 if (
   Object.keys(dependencies || {}).length > 0 &&
   fs.existsSync(nodeModulesPath)
 ) {
-  const electronRebuildCmd =
-    '../node_modules/.bin/electron-rebuild --parallel --force --types prod,dev,optional --module-dir .';
+  const electronRebuildCmd = `${path.join(
+    getModulesPath(__dirname),
+    './.bin/electron-rebuild'
+  )} --parallel --force --types prod,dev,optional --module-dir .`;
 
   const cmd =
     process.platform === 'win32'

--- a/internals/scripts/RunTests.js
+++ b/internals/scripts/RunTests.js
@@ -1,5 +1,6 @@
 import spawn from 'cross-spawn';
 import path from 'path';
+import getModulesPath from 'node-modules-path';
 
 const pattern =
   process.argv[2] === 'e2e'
@@ -7,7 +8,7 @@ const pattern =
     : 'test/(?!e2e/)[^/]+/.+\\.spec\\.js$';
 
 const result = spawn.sync(
-  path.normalize('./node_modules/.bin/jest'),
+  path.join(getModulesPath(__dirname), './.bin/jest'),
   [pattern, ...process.argv.slice(2)],
   { stdio: 'inherit' }
 );

--- a/package.json
+++ b/package.json
@@ -231,6 +231,7 @@
     "devtron": "^1.4.0",
     "electron-debug": "^2.0.0",
     "history": "^4.7.2",
+    "node-modules-path": "^1.0.1",
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
     "react-hot-loader": "^4.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7294,6 +7294,10 @@ node-ipc@^9.1.0:
     util "^0.10.3"
     vm-browserify "0.0.4"
 
+node-modules-path@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/node-modules-path/-/node-modules-path-1.0.1.tgz#40096b08ce7ad0ea14680863af449c7c75a5d1c8"
+
 node-notifier@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.2.1.tgz#fa313dd08f5517db0e2502e5758d664ac69f9dea"


### PR DESCRIPTION
Partially helps #1689.

Avoid assuming the location of `node_modules`. Instead, use `node-modules-path` to get the path to the nearest `node_modules`.

We will also have to switch the jest config in `package.json` to a `jest.config.js` to utilize `node-modules-path` for `moduleDirectories`. So for now, the assumption is still there during testing.