### PR TITLE
Fix webpack path for dev

### DIFF
--- a/configs/webpack.config.renderer.dev.js
+++ b/configs/webpack.config.renderer.dev.js
@@ -49,7 +49,7 @@ export default merge.smart(baseConfig, {
     'react-hot-loader/patch',
     `webpack-dev-server/client?http://localhost:${port}/`,
     'webpack/hot/only-dev-server',
-    path.join(__dirname, 'app/index.js')
+    path.join(__dirname, '..', 'app/index.js')
   ],
 
   output: {


### PR DESCRIPTION
There was an incorrect path to `app/index.js` which raised an error when running `yarn dev` that the file could not be found.