### PR TITLE
Specify yarn instead of npm in CheckNativeDep.js

### DIFF
--- a/internals/scripts/CheckNativeDep.js
+++ b/internals/scripts/CheckNativeDep.js
@@ -16,10 +16,10 @@ import { dependencies } from '../../package';
     // Find the reason for why the dependency is installed. If it is installed
     // because of a devDependency then that is okay. Warn when it is installed
     // because of a dependency
-    const dependenciesObject = JSON.parse(
+    const { dependencies: dependenciesObject } = JSON.parse(
       execSync(`npm ls ${nativeDeps.join(' ')} --json`).toString()
     );
-    const rootDependencies = Object.keys(dependenciesObject.dependencies);
+    const rootDependencies = Object.keys(dependenciesObject);
     const filteredRootDependencies = rootDependencies.filter(rootDependency =>
       dependenciesKeys.includes(rootDependency)
     );
@@ -37,15 +37,15 @@ ${chalk.bold(filteredRootDependencies.join(', '))} ${
 
 
 First uninstall the packages from "./package.json":
-${chalk.whiteBright.bgGreen.bold('npm uninstall your-package')}
+${chalk.whiteBright.bgGreen.bold('yarn remove your-package')}
 
 ${chalk.bold(
         'Then, instead of installing the package to the root "./package.json":'
       )}
-${chalk.whiteBright.bgRed.bold('npm install your-package --save')}
+${chalk.whiteBright.bgRed.bold('yarn add your-package')}
 
 ${chalk.bold('Install the package to "./app/package.json"')}
-${chalk.whiteBright.bgGreen.bold('cd ./app && npm install your-package --save')}
+${chalk.whiteBright.bgGreen.bold('cd ./app && yarn add your-package')}
 
 
 Read more about native dependencies at:


### PR DESCRIPTION
Since we've updated the `README` and `package.json` to use `yarn` over `npm`, we should do the same in the `CheckNativeDep` postinstall.

`npm ls` doesn't seem to have a yarn equivalent, but we should figure out a way to replace that since we're not specifying `npm` as a requirement anymore and it's not a dependency.