### PR TITLE
Disable flow in appveyor until fixed

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,7 +42,7 @@ before_test:
 test_script:
   - yarn package-ci
   - yarn lint
-  - yarn flow
+  # - yarn flow
   - yarn test
   - yarn build-e2e
   - yarn test-e2e


### PR DESCRIPTION
It seems `flow-bin` is the reason `appveyor` tests are failing on Windows.

Even `flow-bin`'s Windows tests on `appveyor` have not been passing.

In another repository of mine, the same issue happened on `appveyor` testing with Windows.

I say disable testing `flow` on Windows until we find out more.