### PR TITLE
Use require.resolve where path is unnecessary

### DIFF
--- a/configs/webpack.config.base.js
+++ b/configs/webpack.config.base.js
@@ -19,9 +19,7 @@ function filterDepWithoutEntryPoints(dep: string): boolean {
       return false;
     }
     const pgkString = fs
-      .readFileSync(
-        path.join(__dirname, '..', `node_modules/${dep}/package.json`)
-      )
+      .readFileSync(require.resolve(`${dep}/package`))
       .toString();
     const pkg = JSON.parse(pgkString);
     const fields = ['main', 'module', 'jsnext:main', 'browser'];

--- a/configs/webpack.config.renderer.dev.js
+++ b/configs/webpack.config.renderer.dev.js
@@ -49,7 +49,7 @@ export default merge.smart(baseConfig, {
     'react-hot-loader/patch',
     `webpack-dev-server/client?http://localhost:${port}/`,
     'webpack/hot/only-dev-server',
-    path.join(__dirname, '..', 'app/index.js')
+    require.resolve('../app/index')
   ],
 
   output: {


### PR DESCRIPTION
In certain cases `path` is being used to create a path to an existing file, which `require.resolve` could also do with less string concatenation (and it may be supported by `eslint-plugin-import` in the future).